### PR TITLE
Add mac address filtering

### DIFF
--- a/internal/provider/mac.go
+++ b/internal/provider/mac.go
@@ -1,0 +1,16 @@
+package provider
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var macAddressRegexp = regexp.MustCompile("^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$")
+
+func macDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	old = strings.TrimSpace(strings.ReplaceAll(strings.ToLower(old), "-", ":"))
+	new = strings.TrimSpace(strings.ReplaceAll(strings.ToLower(new), "-", ":"))
+	return old == new
+}

--- a/internal/provider/resource_network_test.go
+++ b/internal/provider/resource_network_test.go
@@ -43,7 +43,7 @@ func TestAccNetwork_weird_cidr(t *testing.T) {
 		// TODO: CheckDestroy: ,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkConfig("10.0.202.3/24", 202, true),
+				Config: testAccNetworkConfig("10.0.202.3/24", 204, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("unifi_network.test", "subnet", "10.0.202.0/24"),
 				),

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -1,8 +1,6 @@
 package provider
 
 import (
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/paultyng/go-unifi/unifi"
 )
@@ -19,14 +17,10 @@ func resourceUser() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"mac": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					old = strings.TrimSpace(strings.ReplaceAll(strings.ToLower(old), "-", ":"))
-					new = strings.TrimSpace(strings.ReplaceAll(strings.ToLower(new), "-", ":"))
-					return old == new
-				},
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: macDiffSuppressFunc,
 				// Validation:
 			},
 			"name": {

--- a/internal/provider/resource_wlan_test.go
+++ b/internal/provider/resource_wlan_test.go
@@ -72,6 +72,20 @@ func TestAccWLAN_open(t *testing.T) {
 				),
 			},
 			importStep("unifi_wlan.test"),
+			{
+				Config: testAccWLANConfig_open_mac_filter,
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
+			{
+				Config: testAccWLANConfig_open,
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
 		},
 	})
 }
@@ -147,5 +161,25 @@ resource "unifi_wlan" "test" {
 	wlan_group_id = data.unifi_wlan_group.default.id
 	user_group_id = data.unifi_user_group.default.id
 	security      = "open"
+}
+`
+
+const testAccWLANConfig_open_mac_filter = `
+data "unifi_wlan_group" "default" {
+}
+
+data "unifi_user_group" "default" {
+}
+
+resource "unifi_wlan" "test" {
+	name          = "tfacc-open"
+	vlan_id       = 202
+	wlan_group_id = data.unifi_wlan_group.default.id
+	user_group_id = data.unifi_user_group.default.id
+	security      = "open"
+
+	mac_filter_enabled = true
+	mac_filter_list    = ["ab:cd:ef:12:34:56"]
+	mac_filter_policy  = "allow"
 }
 `


### PR DESCRIPTION
I added mac_filtering, since I require it for my home site ...
I imported my current config, that seems to work. 
Also added mac validation in the schema, might make another PR for the user mac address validation there as well.
I'm not quite sure how to write the test for this, I tought adding extra elements in the open wlan test block would solve it, but the test don't seem to go right ...
```
const testAccWLANConfig_open = `
data "unifi_wlan_group" "default" {
}

data "unifi_user_group" "default" {
}

resource "unifi_wlan" "test" {
        name          = "tfacc-open"
        vlan_id       = 202
        wlan_group_id = data.unifi_wlan_group.default.id
        user_group_id = data.unifi_user_group.default.id
        security      = "open"
        mac_filter_enabled = true
        mac_filter_list    = ["ab:cd:ef:12:34:56"]
        mac_filter_policy  = "deny"
}
```

I added the block in the test file, but I keep getting validation error, which I don't quite manage to solve. If you are able to offer some guidance ... I don' have that much experience writing provider code.

```
=== CONT  TestAccFirewallGroup_address_group
panic: interface conversion: interface {} is []interface {}, not []string

goroutine 1375 [running]:
```
An enhancement would be to check the array and validate the elements in them and the order of the elements, to make sure you're not altering the contents when switching elements of place, but as I said, I'm not quite there yet at provider coding level.