### PR TITLE
resource_firewall_rule: enable firewall rules

### DIFF
--- a/internal/provider/resource_firewall_rule.go
+++ b/internal/provider/resource_firewall_rule.go
@@ -156,6 +156,7 @@ func resourceFirewallRuleGetResourceData(d *schema.ResourceData) (*unifi.Firewal
 	}
 
 	return &unifi.FirewallRule{
+		Enabled:          true,
 		Name:             d.Get("name").(string),
 		Action:           d.Get("action").(string),
 		Ruleset:          d.Get("ruleset").(string),


### PR DESCRIPTION
Firewall rules should be enabled by default. Disabled firewall rules should simply be commented out in Terraform files.