### PR TITLE
Added build number to terraform provider binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ before:
 builds:
 - env:
   - CGO_ENABLED=0
+  binary: terraform-provider-unifi_v{{.Version}}
   goos:
     - freebsd
     - openbsd


### PR DESCRIPTION
The way the binary is currently built doesn't include the version
number.

This means that `terraform --version` doesn't pick up the version

```shell
$ terraform --version                                                        [130]
Terraform v0.12.24
+ provider.unifi (unversioned)
```

Adding the binary name in line with
https://www.terraform.io/docs/configuration/providers.html#plugin-names-and-versions
will let it show up correctly.

I haven't used goreleaser before, so let me know if there is a nicer method of handling this.