### PR TITLE
add support for adding IPv6 to a network

### DIFF
--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -107,8 +107,8 @@ unifi_network manages LAN/VLAN networks.
 				Optional:    true,
 				Default:     "none",
 			},
-			"ipv6_static_prefix": {
-				Description: "Specifies the static IPv6 prefix when ipv6_interface_type is 'static'.",
+			"ipv6_static_subnet": {
+				Description: "Specifies the static IPv6 subnet when ipv6_interface_type is 'static'.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
@@ -181,7 +181,7 @@ func resourceNetworkGetResourceData(d *schema.ResourceData) (*unifi.Network, err
 		Enabled: true,
 
 		IPV6InterfaceType: d.Get("ipv6_interface_type").(string),
-		IPV6Subnet:        d.Get("ipv6_static_prefix").(string),
+		IPV6Subnet:        d.Get("ipv6_static_subnet").(string),
 		IPV6PDInterface:   d.Get("ipv6_pd_interface").(string),
 		IPV6PDPrefixid:    d.Get("ipv6_pd_prefixid").(string),
 		IPV6RaEnabled:     d.Get("ipv6_ra_enable").(bool),
@@ -227,7 +227,7 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData)
 	d.Set("igmp_snooping", resp.IGMPSnooping)
 	d.Set("dhcp_dns", dhcpDNS)
 	d.Set("ipv6_interface_type", resp.IPV6InterfaceType)
-	d.Set("ipv6_static_prefix", resp.IPV6Subnet)
+	d.Set("ipv6_static_subnet", resp.IPV6Subnet)
 	d.Set("ipv6_pd_interface", resp.IPV6PDInterface)
 	d.Set("ipv6_pd_prefixid", resp.IPV6PDPrefixid)
 	d.Set("ipv6_ra_enable", resp.IPV6RaEnabled)

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -101,6 +101,32 @@ unifi_network manages LAN/VLAN networks.
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
+			"ipv6_interface_type": {
+				Description: "Specifies which type of IPv6 connection to use.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "none",
+			},
+			"ipv6_static_prefix": {
+				Description: "Specifies the static IPv6 prefix when ipv6_interface_type is 'static'.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"ipv6_pd_interface": {
+				Description: "Specifies which WAN interface to use for IPv6 PD.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"ipv6_pd_prefixid": {
+				Description: "Specifies the IPv6 Prefix ID.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"ipv6_ra_enable": {
+				Description: "Specifies whether to enable router advertisements or not.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -152,11 +178,13 @@ func resourceNetworkGetResourceData(d *schema.ResourceData) (*unifi.Network, err
 
 		VLANEnabled: vlan != 0 && vlan != 1,
 
-		Enabled:           true,
-		IPV6InterfaceType: "none",
-		// IPV6InterfaceType string `json:"ipv6_interface_type"` // "none"
-		// IPV6PDStart       string `json:"ipv6_pd_start"`       // "::2"
-		// IPV6PDStop        string `json:"ipv6_pd_stop"`        // "::7d1"
+		Enabled: true,
+
+		IPV6InterfaceType: d.Get("ipv6_interface_type").(string),
+		IPV6Subnet:        d.Get("ipv6_static_prefix").(string),
+		IPV6PDInterface:   d.Get("ipv6_pd_interface").(string),
+		IPV6PDPrefixid:    d.Get("ipv6_pd_prefixid").(string),
+		IPV6RaEnabled:     d.Get("ipv6_ra_enable").(bool),
 	}, nil
 }
 
@@ -198,6 +226,11 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData)
 	d.Set("domain_name", resp.DomainName)
 	d.Set("igmp_snooping", resp.IGMPSnooping)
 	d.Set("dhcp_dns", dhcpDNS)
+	d.Set("ipv6_interface_type", resp.IPV6InterfaceType)
+	d.Set("ipv6_static_prefix", resp.IPV6Subnet)
+	d.Set("ipv6_pd_interface", resp.IPV6PDInterface)
+	d.Set("ipv6_pd_prefixid", resp.IPV6PDPrefixid)
+	d.Set("ipv6_ra_enable", resp.IPV6RaEnabled)
 
 	return nil
 }

--- a/internal/provider/resource_network_test.go
+++ b/internal/provider/resource_network_test.go
@@ -166,8 +166,8 @@ resource "unifi_network" "test" {
 	dhcp_enabled  = true
 	domain_name   = "foo.local"
 
-	ipv6_interface_type = %s
-	ipv6_pd_interface = %s
+	ipv6_interface_type = "%s"
+	ipv6_pd_interface = "%s"
 	ipv6_pd_prefixid = "1"
 	ipv6_ra_enable = true
 }

--- a/internal/provider/resource_network_test.go
+++ b/internal/provider/resource_network_test.go
@@ -94,23 +94,21 @@ func TestAccNetwork_v6(t *testing.T) {
 		// TODO: CheckDestroy: ,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkConfigV6("10.0.204.0/24", 204, "pd", "wan"),
+				Config: testAccNetworkConfigV6("10.0.206.0/24", 206, "static", "fd6a:37be:e362::1/64"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("unifi_network.test", "domain_name", "foo.local"),
-					resource.TestCheckResourceAttr("unifi_network.test", "subnet", "10.0.202.0/24"),
-					resource.TestCheckResourceAttr("unifi_network.test", "vlan_id", "202"),
-					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_interface_type", "pd"),
-					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_pd_interface", "wan"),
+					resource.TestCheckResourceAttr("unifi_network.test", "subnet", "10.0.206.0/24"),
+					resource.TestCheckResourceAttr("unifi_network.test", "vlan_id", "206"),
+					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_static_subnet", "fd6a:37be:e362::1/64"),
 				),
 			},
 			importStep("unifi_network.test"),
 			{
-				Config: testAccNetworkConfigV6("10.0.205.0/24", 205, "none", ""),
+				Config: testAccNetworkConfigV6("10.0.207.0/24", 207, "static", "fd6a:37be:e363::1/64"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("unifi_network.test", "subnet", "10.0.203.0/24"),
-					resource.TestCheckResourceAttr("unifi_network.test", "vlan_id", "203"),
-					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_interface_type", "none"),
-					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_pd_interface", ""),
+					resource.TestCheckResourceAttr("unifi_network.test", "subnet", "10.0.207.0/24"),
+					resource.TestCheckResourceAttr("unifi_network.test", "vlan_id", "207"),
+					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_static_subnet", "fd6a:37be:e363::1/64"),
 				),
 			},
 			importStep("unifi_network.test"),
@@ -149,7 +147,7 @@ resource "unifi_network" "test" {
 `, subnet, vlan, igmpSnoop, strings.Join(quoteStrings(dhcpDNS), ","))
 }
 
-func testAccNetworkConfigV6(subnet string, vlan int, ipv6Type string, ipv6Interface string) string {
+func testAccNetworkConfigV6(subnet string, vlan int, ipv6Type string, ipv6Subnet string) string {
 	return fmt.Sprintf(`
 variable "subnet" {
 	default = "%s"
@@ -167,9 +165,8 @@ resource "unifi_network" "test" {
 	domain_name   = "foo.local"
 
 	ipv6_interface_type = "%s"
-	ipv6_pd_interface = "%s"
-	ipv6_pd_prefixid = "1"
+	ipv6_static_subnet = "%s"
 	ipv6_ra_enable = true
 }
-`, subnet, vlan, ipv6Type, ipv6Interface)
+`, subnet, vlan, ipv6Type, ipv6Subnet)
 }


### PR DESCRIPTION
This adds the ability to add some IPv6 settings to a network. I wasn't quite sure how to do the tests here, totally open to feedback.

I was able to make this work with the following:

```
resource "unifi_network" "testnet-v6" {
  name    = "testnet-v6"
  purpose = "corporate"

  subnet       = "10.6.0.1/24"
  vlan_id      = "6"
  dhcp_start   = "10.6.0.200"
  dhcp_stop    = "10.6.0.250"
  dhcp_enabled = true
  dhcp_dns     = ["172.23.201.3"]

  ipv6_interface_type = "pd"
  ipv6_pd_interface   = "wan"
  ipv6_pd_prefixid    = "6"
  ipv6_ra_enable      = true
}
```