### PR TITLE
Check for updates to GitHub Actions and Go modules every weekday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+
+  # Maintain dependencies for Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      # Check for updates to Go modules every weekday
+      interval: "daily"


### PR DESCRIPTION
Saw that that this provider was using GitHub actions. Checking for updates against those actions I thought wouldn't hurt now that dependabot is built into GitHub natively.