### PR TITLE
Implement site resource

### DIFF
--- a/docs/resources/site.md
+++ b/docs/resources/site.md
@@ -1,0 +1,31 @@
+---
+page_title: "unifi_site Resource - terraform-provider-unifi"
+subcategory: ""
+description: |-
+  unifi_site manages Unifi sites
+---
+
+# Resource `unifi_site`
+
+`unifi_site` manages Unifi sites
+
+## Example Usage
+
+```terraform
+resource "unifi_site" "mysite" {
+  description = "mysite"
+}
+```
+
+## Schema
+
+### Required
+
+- **description** (String, Required) The description of the site.
+
+### Read-only
+
+- **id** (String, Read-only) The ID of the site.
+- **name** (String, Read-only) The name of the site.
+
+

--- a/examples/resources/unifi_site/resource.tf
+++ b/examples/resources/unifi_site/resource.tf
@@ -1,0 +1,3 @@
+resource "unifi_site" "mysite" {
+  description = "mysite"
+}

--- a/internal/provider/lazy_client.go
+++ b/internal/provider/lazy_client.go
@@ -307,3 +307,33 @@ func (c *lazyClient) UpdateRADIUSProfile(ctx context.Context, site string, d *un
 	}
 	return c.inner.UpdateRADIUSProfile(ctx, site, d)
 }
+func (c *lazyClient) GetSite(ctx context.Context, id string) (*unifi.Site, error) {
+	if err := c.init(ctx); err != nil {
+		return nil, err
+	}
+	return c.inner.GetSite(ctx, id)
+}
+func (c *lazyClient) ListSites(ctx context.Context) ([]unifi.Site, error) {
+	if err := c.init(ctx); err != nil {
+		return nil, err
+	}
+	return c.inner.ListSites(ctx)
+}
+func (c *lazyClient) CreateSite(ctx context.Context, description string) ([]unifi.Site, error) {
+	if err := c.init(ctx); err != nil {
+		return nil, err
+	}
+	return c.inner.CreateSite(ctx, description)
+}
+func (c *lazyClient) DeleteSite(ctx context.Context, id string) ([]unifi.Site, error) {
+	if err := c.init(ctx); err != nil {
+		return nil, err
+	}
+	return c.inner.DeleteSite(ctx, id)
+}
+func (c *lazyClient) UpdateSite(ctx context.Context, name, description string) ([]unifi.Site, error) {
+	if err := c.init(ctx); err != nil {
+		return nil, err
+	}
+	return c.inner.UpdateSite(ctx, name, description)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -77,6 +77,7 @@ func New(version string) func() *schema.Provider {
 				"unifi_user_group":     resourceUserGroup(),
 				"unifi_user":           resourceUser(),
 				"unifi_wlan":           resourceWLAN(),
+				"unifi_site":           resourceSite(),
 			},
 		}
 		p.ConfigureFunc = configure(version, p)
@@ -155,6 +156,12 @@ type unifiClient interface {
 	DeleteRADIUSProfile(ctx context.Context, site, id string) error
 	CreateRADIUSProfile(ctx context.Context, site string, d *unifi.RADIUSProfile) (*unifi.RADIUSProfile, error)
 	UpdateRADIUSProfile(ctx context.Context, site string, d *unifi.RADIUSProfile) (*unifi.RADIUSProfile, error)
+
+	GetSite(ctx context.Context, id string) (*unifi.Site, error)
+	ListSites(ctx context.Context) ([]unifi.Site, error)
+	CreateSite(ctx context.Context, Description string) ([]unifi.Site, error)
+	UpdateSite(ctx context.Context, Name, Description string) ([]unifi.Site, error)
+	DeleteSite(ctx context.Context, ID string) ([]unifi.Site, error)
 }
 
 type client struct {

--- a/internal/provider/resource_site.go
+++ b/internal/provider/resource_site.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/paultyng/go-unifi/unifi"
+)
+
+func resourceSite() *schema.Resource {
+	return &schema.Resource{
+		Description: "`unifi_site` manages Unifi sites",
+
+		Create: resourceSiteCreate,
+		Read:   resourceSiteRead,
+		Update: resourceSiteUpdate,
+		Delete: resourceSiteDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the site.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"description": {
+				Description: "The description of the site.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"name": {
+				Description: "The name of the site.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceSiteCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*client)
+
+	description := d.Get("description").(string)
+
+	resp, err := c.c.CreateSite(context.TODO(), description)
+	if err != nil {
+		return err
+	}
+
+	site := resp[0]
+	d.SetId(site.ID)
+
+	return resourceSiteSetResourceData(&site, d)
+}
+
+func resourceSiteSetResourceData(resp *unifi.Site, d *schema.ResourceData) error {
+	d.Set("name", resp.Name)
+	d.Set("description", resp.Description)
+	return nil
+}
+
+func resourceSiteRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*client)
+
+	id := d.Id()
+
+	site, err := c.c.GetSite(context.TODO(), id)
+	if _, ok := err.(*unifi.NotFoundError); ok {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return resourceSiteSetResourceData(site, d)
+}
+
+func resourceSiteUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*client)
+
+	site := &unifi.Site{
+		ID:          d.Id(),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	resp, err := c.c.UpdateSite(context.TODO(), site.Name, site.Description)
+	if err != nil {
+		return err
+	}
+
+	return resourceSiteSetResourceData(&resp[0], d)
+}
+
+func resourceSiteDelete(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*client)
+	id := d.Id()
+	_, err := c.c.DeleteSite(context.TODO(), id)
+	return err
+}

--- a/internal/provider/resource_site_test.go
+++ b/internal/provider/resource_site_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccSite_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { preCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckSiteResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSiteConfig,
+			},
+		},
+	})
+}
+
+func testAccCheckSiteResourceDestroy(s *terraform.State) error {
+	sites, err := testClient.ListSites(context.Background())
+	if err != nil {
+		return err
+	}
+	for _, site := range sites {
+		if site.Description == "tfacc" {
+			return fmt.Errorf("site tfacc not destroyed")
+		}
+	}
+	return nil
+}
+
+const testAccSiteConfig = `
+resource "unifi_site" "test" {
+	description = "tfacc"
+}
+`


### PR DESCRIPTION
This PR is the beginning of my attempt to address: https://github.com/paultyng/terraform-provider-unifi/issues/16

I have implemented the `unifi_site` resource. I will first wait for my PR on the unifi client to be approved (https://github.com/paultyng/go-unifi/pull/12) before this one is ready but this should give everyone an idea of what I would like to see added to this provider.

Next steps after this is merged would be to go through all the other resources and allow setting the site name/id on them to create them in the appropriate site. Hopefully I would be able to do that in a backwards compatible way.
