### PR TITLE
Feature/support sites

### DIFF
--- a/controller.sh
+++ b/controller.sh
@@ -52,7 +52,7 @@ case "$1" in
   "reset")
     git checkout - testdata/unifi/
     for file in $( git ls-files --others --exclude-standard | grep testdata/unifi ) ; do
-            rm -f ${file}
+            rm -f ${file} || sudo rm -f ${file}
     done
     ;;
   *)

--- a/controller.sh
+++ b/controller.sh
@@ -52,7 +52,7 @@ case "$1" in
   "reset")
     git checkout - testdata/unifi/
     for file in $( git ls-files --others --exclude-standard | grep testdata/unifi ) ; do
-            rm -f ${file} || sudo rm -f ${file}
+            rm -f ${file}
     done
     ;;
   *)

--- a/docs/data-sources/ap_group.md
+++ b/docs/data-sources/ap_group.md
@@ -21,6 +21,7 @@ data "unifi_ap_group" "default" {
 ### Optional
 
 - **name** (String, Optional) The name of the AP group to look up, leave blank to look up the default AP group.
+- **site** (String, Optional) The name of the site the AP group is associated with.
 
 ### Read-only
 

--- a/docs/data-sources/radius_profile.md
+++ b/docs/data-sources/radius_profile.md
@@ -16,6 +16,7 @@ description: |-
 ### Optional
 
 - **name** (String, Optional) The name of the RADIUS profile to look up. Defaults to `Default`.
+- **site** (String, Optional) The name of the site the radius profile is associated with.
 
 ### Read-only
 

--- a/docs/data-sources/user_group.md
+++ b/docs/data-sources/user_group.md
@@ -16,6 +16,7 @@ description: |-
 ### Optional
 
 - **name** (String, Optional) The name of the user group to look up. Defaults to `Default`.
+- **site** (String, Optional) The name of the site the user group is associated with.
 
 ### Read-only
 

--- a/docs/data-sources/wlan_group.md
+++ b/docs/data-sources/wlan_group.md
@@ -19,6 +19,7 @@ Please note that WLAN Groups are deprecated in v6 of the controller.
 ### Optional
 
 - **name** (String, Optional) The name of the WLAN group to look up. Defaults to `Default`.
+- **site** (String, Optional) The name of the site the wlan group is associated with.
 
 ### Read-only
 

--- a/docs/resources/firewall_group.md
+++ b/docs/resources/firewall_group.md
@@ -32,6 +32,10 @@ resource "unifi_firewall_group" "can_print" {
 - **name** (String, Required) The name of the firewall group.
 - **type** (String, Required) The type of the firewall group. Must be one of: `address-group`, `port-group`, or `ipv6-address-group`.
 
+### Optional
+
+- **site** (String, Optional) The name of the site to associate the firewall group with.
+
 ### Read-only
 
 - **id** (String, Read-only) The ID of the firewall group.

--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -47,6 +47,7 @@ resource "unifi_firewall_rule" "drop_all" {
 - **dst_network_type** (String, Optional) The destination network type of the firewall rule. Can be one of `ADDRv4` or `NETv4`. Defaults to `NETv4`.
 - **ip_sec** (String, Optional) Specify whether the rule matches on IPsec packets. Can be one of `match-ipset` or `match-none`.
 - **logging** (Boolean, Optional) Enable logging for the firewall rule.
+- **site** (String, Optional) The name of the site to associate the firewall rule with.
 - **src_address** (String, Optional) The source address for the firewall rule.
 - **src_firewall_group_ids** (Set of String, Optional) The source firewall group IDs for the firewall rule.
 - **src_mac** (String, Optional) The source MAC address of the firewall rule.

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -62,6 +62,7 @@ resource "unifi_network" "wan" {
 - **ipv6_ra_enable** (Boolean, Optional) Specifies whether to enable router advertisements or not.
 - **ipv6_static_subnet** (String, Optional) Specifies the static IPv6 subnet when ipv6_interface_type is 'static'.
 - **network_group** (String, Optional) The group of the network. Defaults to `LAN`.
+- **site** (String, Optional) The name of the site to associate the network with.
 - **subnet** (String, Optional) The subnet of the network. Must be a valid CIDR address.
 - **vlan_id** (Number, Optional) The VLAN ID of the network.
 - **wan_egress_qos** (Number, Optional) Specifies the WAN egress quality of service. Defaults to `0`.

--- a/docs/resources/port_forward.md
+++ b/docs/resources/port_forward.md
@@ -23,6 +23,7 @@ description: |-
 - **name** (String, Optional) The name of the port forwarding rule.
 - **port_forward_interface** (String, Optional) The port forwarding interface. Can be `wan`, `wan2`, or `both`.
 - **protocol** (String, Optional) The protocol for the port forwarding rule. Can be `tcp`, `udp`, or `tcp_udp`. Defaults to `tcp_udp`.
+- **site** (String, Optional) The name of the site to associate the port forwarding rule with.
 - **src_ip** (String, Optional) The source IPv4 address (or CIDR) of the port forwarding rule. For all traffic, specify `any`. Defaults to `any`.
 
 ### Read-only

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -39,6 +39,7 @@ resource "unifi_user" "test" {
 - **fixed_ip** (String, Optional) A fixed IPv4 address for this user.
 - **network_id** (String, Optional) The network ID for this user.
 - **note** (String, Optional) A note with additional information for the user.
+- **site** (String, Optional) The name of the site to associate the user with.
 - **skip_forget_on_destroy** (Boolean, Optional) Specifies whether this resource should tell the controller to "forget" the user on destroy. Defaults to `false`.
 - **user_group_id** (String, Optional) The user group ID for the user.
 

--- a/docs/resources/user_group.md
+++ b/docs/resources/user_group.md
@@ -30,6 +30,7 @@ resource "unifi_user_group" "wifi" {
 
 - **qos_rate_max_down** (Number, Optional) The QOS maximum download rate. Defaults to `-1`.
 - **qos_rate_max_up** (Number, Optional) The QOS maximum upload rate. Defaults to `-1`.
+- **site** (String, Optional) The name of the site to associate the user group with.
 
 ### Read-only
 

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -49,6 +49,7 @@ resource "unifi_wlan" "wifi" {
 - **passphrase** (String, Optional) The passphrase for the network, this is only required if `security` is not set to `open`.
 - **radius_profile_id** (String, Optional) ID of the RADIUS profile to use when security `wpaeap`. You can query this via the `unifi_radius_profile` data source.
 - **schedule** (Block List) Start and stop schedules for the WLAN (see [below for nested schema](#nestedblock--schedule))
+- **site** (String, Optional) The name of the site to associate the wlan with.
 - **vlan_id** (Number, Optional, Deprecated) VLAN ID for the network. Set network_id instead of vlan_id for controller version >= 6.
 - **wlan_group_id** (String, Optional, Deprecated) ID of the WLAN group to use for this network. Set ap_group_ids instead of wlan_group_id for controller version >= 6.
 

--- a/internal/provider/data_ap_group.go
+++ b/internal/provider/data_ap_group.go
@@ -19,6 +19,12 @@ func dataAPGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"site": {
+				Description: "The name of the site the AP group is associated with.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+			},
 			"name": {
 				Description: "The name of the AP group to look up, leave blank to look up the default AP group.",
 				Type:        schema.TypeString,
@@ -36,14 +42,19 @@ func dataAPGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	name := d.Get("name").(string)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
 
-	groups, err := c.c.ListAPGroup(context.TODO(), c.site)
+	groups, err := c.c.ListAPGroup(context.TODO(), site)
 	if err != nil {
 		return err
 	}
 	for _, g := range groups {
 		if (name == "" && g.HiddenID == "default") || g.Name == name {
 			d.SetId(g.ID)
+			d.Set("site", site)
 			return nil
 		}
 	}

--- a/internal/provider/data_radius_profile.go
+++ b/internal/provider/data_radius_profile.go
@@ -19,6 +19,12 @@ func dataRADIUSProfile() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"site": {
+				Description: "The name of the site the radius profile is associated with.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+			},
 			"name": {
 				Description: "The name of the RADIUS profile to look up.",
 				Type:        schema.TypeString,
@@ -33,14 +39,19 @@ func dataRADIUSProfileRead(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*client)
 
 	name := d.Get("name").(string)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
 
-	profiles, err := c.c.ListRADIUSProfile(context.TODO(), c.site)
+	profiles, err := c.c.ListRADIUSProfile(context.TODO(), site)
 	if err != nil {
 		return err
 	}
 	for _, g := range profiles {
 		if g.Name == name {
 			d.SetId(g.ID)
+			d.Set("site", site)
 			return nil
 		}
 	}

--- a/internal/provider/data_user_group.go
+++ b/internal/provider/data_user_group.go
@@ -19,6 +19,12 @@ func dataUserGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"site": {
+				Description: "The name of the site the user group is associated with.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+			},
 			"name": {
 				Description: "The name of the user group to look up.",
 				Type:        schema.TypeString,
@@ -42,8 +48,12 @@ func dataUserGroupRead(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*client)
 
 	name := d.Get("name").(string)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
 
-	groups, err := c.c.ListUserGroup(context.TODO(), c.site)
+	groups, err := c.c.ListUserGroup(context.TODO(), site)
 	if err != nil {
 		return err
 	}
@@ -51,6 +61,7 @@ func dataUserGroupRead(d *schema.ResourceData, meta interface{}) error {
 		if g.Name == name {
 			d.SetId(g.ID)
 
+			d.Set("site", site)
 			d.Set("qos_rate_max_down", g.QOSRateMaxDown)
 			d.Set("qos_rate_max_up", g.QOSRateMaxUp)
 

--- a/internal/provider/data_wlan_group.go
+++ b/internal/provider/data_wlan_group.go
@@ -22,6 +22,12 @@ func dataWLANGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"site": {
+				Description: "The name of the site the wlan group is associated with.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+			},
 			"name": {
 				Description: "The name of the WLAN group to look up.",
 				Type:        schema.TypeString,
@@ -41,13 +47,19 @@ func dataWLANGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 
-	groups, err := c.c.ListWLANGroup(context.TODO(), c.site)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
+
+	groups, err := c.c.ListWLANGroup(context.TODO(), site)
 	if err != nil {
 		return err
 	}
 	for _, g := range groups {
 		if g.Name == name {
 			d.SetId(g.ID)
+			d.Set("site", site)
 			return nil
 		}
 	}

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -41,6 +41,11 @@ func resourceNetwork() *schema.Resource {
 				Description: "The ID of the network.",
 				Type:        schema.TypeString,
 				Computed:    true,
+			"site_name": {
+				Description: "The name of the site to associate the network with.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "default",
 			},
 			"name": {
 				Description: "The name of the network.",
@@ -195,7 +200,9 @@ func resourceNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	resp, err := c.c.CreateNetwork(context.TODO(), c.site, req)
+	siteName := d.Get("site_name").(string)
+
+	resp, err := c.c.CreateNetwork(context.TODO(), siteName, req)
 	if err != nil {
 		return err
 	}
@@ -309,7 +316,9 @@ func resourceNetworkRead(d *schema.ResourceData, meta interface{}) error {
 
 	id := d.Id()
 
-	resp, err := c.c.GetNetwork(context.TODO(), c.site, id)
+	siteName := d.Get("site_name").(string)
+
+	resp, err := c.c.GetNetwork(context.TODO(), siteName, id)
 	if _, ok := err.(*unifi.NotFoundError); ok {
 		d.SetId("")
 		return nil
@@ -330,9 +339,10 @@ func resourceNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	req.ID = d.Id()
-	req.SiteID = c.site
+	siteName := d.Get("site_name").(string)
+	req.SiteID = siteName
 
-	resp, err := c.c.UpdateNetwork(context.TODO(), c.site, req)
+	resp, err := c.c.UpdateNetwork(context.TODO(), siteName, req)
 	if err != nil {
 		return err
 	}
@@ -344,9 +354,10 @@ func resourceNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*client)
 
 	name := d.Get("name").(string)
+	siteName := d.Get("site_name").(string)
 	id := d.Id()
 
-	err := c.c.DeleteNetwork(context.TODO(), c.site, id, name)
+	err := c.c.DeleteNetwork(context.TODO(), siteName, id, name)
 	if _, ok := err.(*unifi.NotFoundError); ok {
 		return nil
 	}

--- a/internal/provider/resource_user_group.go
+++ b/internal/provider/resource_user_group.go
@@ -26,6 +26,13 @@ func resourceUserGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"site": {
+				Description: "The name of the site to associate the user group with.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Description: "The name of the user group.",
 				Type:        schema.TypeString,
@@ -57,7 +64,12 @@ func resourceUserGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	resp, err := c.c.CreateUserGroup(context.TODO(), c.site, req)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
+
+	resp, err := c.c.CreateUserGroup(context.TODO(), site, req)
 	if err != nil {
 		return err
 	}
@@ -88,7 +100,12 @@ func resourceUserGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	id := d.Id()
 
-	resp, err := c.c.GetUserGroup(context.TODO(), c.site, id)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
+
+	resp, err := c.c.GetUserGroup(context.TODO(), site, id)
 	if _, ok := err.(*unifi.NotFoundError); ok {
 		d.SetId("")
 		return nil
@@ -109,9 +126,14 @@ func resourceUserGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	req.ID = d.Id()
-	req.SiteID = c.site
 
-	resp, err := c.c.UpdateUserGroup(context.TODO(), c.site, req)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
+	req.SiteID = site
+
+	resp, err := c.c.UpdateUserGroup(context.TODO(), site, req)
 	if err != nil {
 		return err
 	}
@@ -124,7 +146,11 @@ func resourceUserGroupDelete(d *schema.ResourceData, meta interface{}) error {
 
 	id := d.Id()
 
-	err := c.c.DeleteUserGroup(context.TODO(), c.site, id)
+	site := d.Get("site").(string)
+	if site == "" {
+		site = c.site
+	}
+	err := c.c.DeleteUserGroup(context.TODO(), site, id)
 	if _, ok := err.(*unifi.NotFoundError); ok {
 		return nil
 	}


### PR DESCRIPTION
So I have been playing around with adding the `site_name` attribute to some of the resources and data sources. I just wanted to open up a PR early as I want to know what the right direction for this change is. At the moment it's a bit messy, I hope you can point me in the right direction.

I have made it so that if you do not specify the `site_name` attribute it defaults to the old behaviour of choosing the site name set on the provider.