### PR TITLE
Support importing networks and wlans from other sites

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -76,4 +76,14 @@ resource "unifi_network" "wan" {
 
 - **id** (String, Read-only) The ID of the network.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# import from provider configured site
+terraform import unifi_network.mynetwork 5dc28e5e9106d105bdc87217
+
+# import from another site
+terraform import unifi_network.mynetwork bfa2l6i7:5dc28e5e9106d105bdc87217
+```

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -66,4 +66,14 @@ Required:
 - **block_start** (String, Required) Time of day to start the block.
 - **day_of_week** (String, Required) Day of week for the block. Valid values are `sun`, `mon`, `tue`, `wed`, `thu`, `fri`, `sat`.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# import from provider configured site
+terraform import unifi_wlan.mywlan 5dc28e5e9106d105bdc87217
+
+# import from another site
+terraform import unifi_wlan.mywlan bfa2l6i7:5dc28e5e9106d105bdc87217
+```

--- a/examples/resources/unifi_network/import.sh
+++ b/examples/resources/unifi_network/import.sh
@@ -1,0 +1,5 @@
+# import from provider configured site
+terraform import unifi_network.mynetwork 5dc28e5e9106d105bdc87217
+
+# import from another site
+terraform import unifi_network.mynetwork bfa2l6i7:5dc28e5e9106d105bdc87217

--- a/examples/resources/unifi_wlan/import.sh
+++ b/examples/resources/unifi_wlan/import.sh
@@ -1,0 +1,5 @@
+# import from provider configured site
+terraform import unifi_wlan.mywlan 5dc28e5e9106d105bdc87217
+
+# import from another site
+terraform import unifi_wlan.mywlan bfa2l6i7:5dc28e5e9106d105bdc87217

--- a/internal/provider/importer.go
+++ b/internal/provider/importer.go
@@ -1,0 +1,16 @@
+package provider
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ImportHandleSite(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if strings.Contains(d.Id(), ":") {
+		importParts := strings.Split(d.Id(), ":")
+		d.SetId(importParts[1])
+		d.Set("site", importParts[0])
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/internal/provider/resource_firewall_group.go
+++ b/internal/provider/resource_firewall_group.go
@@ -17,7 +17,7 @@ func resourceFirewallGroup() *schema.Resource {
 		Update: resourceFirewallGroupUpdate,
 		Delete: resourceFirewallGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportHandleSite,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_firewall_rule.go
+++ b/internal/provider/resource_firewall_rule.go
@@ -20,7 +20,7 @@ func resourceFirewallRule() *schema.Resource {
 		Update: resourceFirewallRuleUpdate,
 		Delete: resourceFirewallRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportHandleSite,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -33,7 +33,7 @@ func resourceNetwork() *schema.Resource {
 		Update: resourceNetworkUpdate,
 		Delete: resourceNetworkDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportHandleSite,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_network_test.go
+++ b/internal/provider/resource_network_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccNetwork_basic(t *testing.T) {
@@ -172,6 +173,21 @@ func TestAccNetwork_differentSite(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("unifi_network.test", "site", "unifi_site.test", "name"),
 				),
+			},
+			{
+				ResourceName: "unifi_network.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceName := "unifi_network.test"
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+					networkID := rs.Primary.Attributes["id"]
+					site := rs.Primary.Attributes["site"]
+					return site + ":" + networkID, nil
+				},
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/resource_port_forward.go
+++ b/internal/provider/resource_port_forward.go
@@ -17,7 +17,7 @@ func resourcePortForward() *schema.Resource {
 		Update: resourcePortForwardUpdate,
 		Delete: resourcePortForwardDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportHandleSite,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -20,7 +20,7 @@ func resourceUser() *schema.Resource {
 		Update: resourceUserUpdate,
 		Delete: resourceUserDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportHandleSite,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_user_group.go
+++ b/internal/provider/resource_user_group.go
@@ -17,7 +17,7 @@ func resourceUserGroup() *schema.Resource {
 		Update: resourceUserGroupUpdate,
 		Delete: resourceUserGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportHandleSite,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_wlan.go
+++ b/internal/provider/resource_wlan.go
@@ -20,7 +20,7 @@ func resourceWLAN() *schema.Resource {
 		Update: resourceWLANUpdate,
 		Delete: resourceWLANDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportHandleSite,
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Because we now have the ability to create multiple sites and resources associated with those sites from a single unifi provider, I now need to be able import a bunch of existing stuff that I have and I have noticed that the default importer implementation does not handle that.

What I have done is added a state importer implementation that checks if there is a `:` character in the id and then I take the left hand side as the site name and the right hand side as the id, this makes the import backwards compatible since if you omit the `:` it will import using the provider site name.