### PR TITLE
wan_type is optional and should not have a default value

### DIFF
--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -163,7 +163,6 @@ func resourceNetwork() *schema.Resource {
 				Description:  "Specifies the IPV4 WAN connection type. Must be one of either `disabled` or `pppoe`.",
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "disabled",
 				ValidateFunc: validateWANType,
 			},
 			"wan_networkgroup": {


### PR DESCRIPTION
wan_type is optional. For example on a purpose = "Corporate" LAN interface this parameter is "". So the default value should be removed.