### PR TITLE
Added support for destination port on the unifi_firewall_rule resource

### DIFF
--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -47,6 +47,7 @@ resource "unifi_firewall_rule" "drop_all" {
 - **dst_firewall_group_ids** (Set of String) The destination firewall group IDs of the firewall rule.
 - **dst_network_id** (String) The destination network ID of the firewall rule.
 - **dst_network_type** (String) The destination network type of the firewall rule. Can be one of `ADDRv4` or `NETv4`. Defaults to `NETv4`.
+- **dst_port** (String) The destination port of the firewall rule.
 - **ip_sec** (String) Specify whether the rule matches on IPsec packets. Can be one of `match-ipset` or `match-none`.
 - **logging** (Boolean) Enable logging for the firewall rule.
 - **site** (String) The name of the site to associate the firewall rule with.

--- a/internal/provider/resource_firewall_rule.go
+++ b/internal/provider/resource_firewall_rule.go
@@ -123,6 +123,12 @@ func resourceFirewallRule() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"dst_port": {
+				Description: "The destination port of the firewall rule.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ValidateFunc: validatePortRange,
+			},
 
 			// advanced
 			"logging": {
@@ -216,6 +222,7 @@ func resourceFirewallRuleGetResourceData(d *schema.ResourceData) (*unifi.Firewal
 
 		DstNetworkType:      d.Get("dst_network_type").(string),
 		DstAddress:          d.Get("dst_address").(string),
+		DstPort:             d.Get("dst_port").(string),
 		DstNetworkID:        d.Get("dst_network_id").(string),
 		DstFirewallGroupIDs: dstFirewallGroupIDs,
 	}, nil
@@ -247,6 +254,7 @@ func resourceFirewallRuleSetResourceData(resp *unifi.FirewallRule, d *schema.Res
 	d.Set("dst_firewall_group_ids", stringSliceToSet(resp.DstFirewallGroupIDs))
 	d.Set("dst_address", resp.DstAddress)
 	d.Set("dst_network_id", resp.DstNetworkID)
+	d.Set("dst_port", resp.DstPort)
 
 	return nil
 }

--- a/internal/provider/resource_firewall_rule_test.go
+++ b/internal/provider/resource_firewall_rule_test.go
@@ -23,6 +23,19 @@ func TestAccFirewallRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccFirewallRule_dst_port(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { preCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallRuleConfigWithPort,
+			},
+			importStep("unifi_firewall_rule.test"),
+		},
+	})
+}
+
 // func TestAccFirewallRule_firewall_group(t *testing.T) {
 // func TestAccFirewallRule_network(t *testing.T) {
 
@@ -46,6 +59,22 @@ resource "unifi_firewall_rule" "test" {
 	src_firewall_group_ids = [unifi_firewall_group.test.id]
 
 	dst_address = "192.168.1.1"
+}
+`
+
+const testAccFirewallRuleConfigWithPort = `
+resource "unifi_firewall_rule" "test" {
+	name    = "tf acc"
+	action  = "accept"
+	ruleset = "LAN_IN"
+
+	rule_index = 2010
+
+	protocol = "tcp"
+
+	src_address = "192.168.3.3"
+	dst_address = "192.168.1.1"
+	dst_port    = 53
 }
 `
 


### PR DESCRIPTION
I noticed this was missing and was using it on a couple of my rules. Let me know if I'm missing anything.