### PR TITLE
Set the default value for network `wan_type` to `disabled`.

### DIFF
--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -164,6 +164,7 @@ func resourceNetwork() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateWANType,
+				Default:      "disabled",
 			},
 			"wan_networkgroup": {
 				Description:  "Specifies the WAN network group. Must be one of either `WAN`, `WAN2` or `WAN_LTE_FAILOVER`.",


### PR DESCRIPTION
I have always been getting dirty plans on my LAN networks where I wasn't explicitly setting `wan_type="disabled"`. The docs say that `disabled` is the default value, but I found that if I did not explicitly specify it, I was getting this in my plan:

```
 ~ resource "unifi_network" "kids" {
        id                  = "<sensored>"
        name                = "Kids"
      - wan_type            = "disabled" -> null
        # (15 unchanged attributes hidden)
    }
```
Furthermore, if I went and tried to apply that plan, it would fail with a pretty cryptic error:
```
Error: not found
```

My apologies for not writing a test for this. I'm brand new to golang, and since this seemed like a simple enough fix, skipped the learning curve for now.