### PR TITLE
Add no2ghz_oui to unifi_wlan resource

### DIFF
--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -64,6 +64,7 @@ resource "unifi_wlan" "wifi" {
 - **mac_filter_policy** (String) MAC address filter policy (only valid if `mac_filter_enabled` is `true`). Defaults to `deny`.
 - **multicast_enhance** (Boolean) Indicates whether or not Multicast Enhance is turned of for the network.
 - **network_id** (String) ID of the network for this SSID
+- **no2ghz_oui** (Boolean) Connect high performance clients to 5 GHz only Defaults to `true`.
 - **passphrase** (String, Sensitive) The passphrase for the network, this is only required if `security` is not set to `open`.
 - **radius_profile_id** (String) ID of the RADIUS profile to use when security `wpaeap`. You can query this via the `unifi_radius_profile` data source.
 - **schedule** (Block List) Start and stop schedules for the WLAN (see [below for nested schema](#nestedblock--schedule))

--- a/internal/provider/resource_wlan.go
+++ b/internal/provider/resource_wlan.go
@@ -131,6 +131,12 @@ func resourceWLAN() *schema.Resource {
 					},
 				},
 			},
+			"no2ghz_oui": {
+				Description: "Connect high performance clients to 5 GHz only",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
 
 			// controller v6 fields
 			// TODO: this could be defaulted to "both" once v5 controller support is dropped
@@ -262,7 +268,7 @@ func resourceWLANGetResourceData(d *schema.ResourceData, meta interface{}) (*uni
 
 		GroupRekey:               3600,
 		DTIMMode:                 "default",
-		No2GhzOui:                true,
+		No2GhzOui:                d.Get("no2ghz_oui").(bool),
 		MinrateNgCckRatesEnabled: true,
 	}, nil
 }
@@ -335,6 +341,7 @@ func resourceWLANSetResourceData(resp *unifi.WLAN, d *schema.ResourceData, meta 
 	d.Set("radius_profile_id", resp.RADIUSProfileID)
 	d.Set("schedule", schedule)
 	d.Set("wlan_band", resp.WLANBand)
+	d.Set("no2ghz_oui", resp.No2GhzOui)
 
 	// switch v := c.ControllerVersion(); {
 	// case v.GreaterThanOrEqual(controllerV6):

--- a/internal/provider/resource_wlan_test.go
+++ b/internal/provider/resource_wlan_test.go
@@ -231,6 +231,33 @@ func TestAccWLAN_wlan_band(t *testing.T) {
 	})
 }
 
+func TestAccWLAN_no2ghz_oui(t *testing.T) {
+	vlanID := getTestVLAN(t)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			preCheck(t)
+			preCheckV6Only(t)
+			wlanPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			// TODO: actual CheckDestroy
+
+			<-wlanConcurrency
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWLANConfig_no2ghz_oui(vlanID),
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
+		},
+	})
+}
+
 func testAccWLANConfig_wpapsk(vlanID int) string {
 	return fmt.Sprintf(`
 data "unifi_ap_group" "default" {
@@ -411,6 +438,36 @@ resource "unifi_wlan" "test" {
 	security      = "wpapsk"
 	wlan_band = "5g"
 	
+	multicast_enhance = true
+}
+`, vlanID)
+}
+
+func testAccWLANConfig_no2ghz_oui(vlanID int) string {
+	return fmt.Sprintf(`
+data "unifi_ap_group" "default" {
+}
+
+data "unifi_user_group" "default" {
+}
+
+resource "unifi_network" "test" {
+	name    = "tfacc"
+	purpose = "corporate"
+
+	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	vlan_id       = %[1]d
+}
+
+resource "unifi_wlan" "test" {
+	name          = "tfacc-wpapsk"
+	network_id    = unifi_network.test.id
+	passphrase    = "12345678"
+	ap_group_ids = [data.unifi_ap_group.default.id]
+	user_group_id = data.unifi_user_group.default.id
+	security      = "wpapsk"
+	no2ghz_oui = false
+
 	multicast_enhance = true
 }
 `, vlanID)

--- a/internal/provider/resource_wlan_v5_test.go
+++ b/internal/provider/resource_wlan_v5_test.go
@@ -169,6 +169,36 @@ func TestAccWLAN_v5_wpaeap(t *testing.T) {
 	})
 }
 
+func TestAccWLAN_v5_no2ghz_oui(t *testing.T) {
+	if os.Getenv("UNIFI_TEST_RADIUS") == "" {
+		t.Skip("UNIFI_TEST_RADIUS not set, skipping RADIUS test")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			preCheck(t)
+			preCheckV5Only(t)
+			wlanPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			// TODO: actual CheckDestroy
+
+			<-wlanConcurrency
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWLANConfig_v5_no2ghz_oui,
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
+		},
+	})
+}
+
 const testAccWLANConfig_v5_wpapsk = `
 data "unifi_wlan_group" "default" {
 }
@@ -271,5 +301,25 @@ resource "unifi_wlan" "test" {
 	mac_filter_enabled = true
 	mac_filter_list    = ["ab:cd:ef:12:34:56"]
 	mac_filter_policy  = "allow"
+}
+`
+
+const testAccWLANConfig_v5_no2ghz_oui = `
+data "unifi_wlan_group" "default" {
+}
+
+data "unifi_user_group" "default" {
+}
+
+resource "unifi_wlan" "test" {
+	name          = "tfacc-wpapsk"
+	vlan_id       = 202
+	passphrase    = "12345678"
+	wlan_group_id = data.unifi_wlan_group.default.id
+	user_group_id = data.unifi_user_group.default.id
+	security      = "wpapsk"
+	no2ghz_oui    = false
+	
+	multicast_enhance = true
 }
 `


### PR DESCRIPTION
The no2ghz_oui field maps to this in the Unifi UI:

![Screenshot_2021-03-08 UniFi Network](https://user-images.githubusercontent.com/2661907/110256509-2db21b80-7ffe-11eb-91b8-7a7d083996da.png)

So I just lifted the description from the UI. hopefully it makes sense.