### PR TITLE
Support importing networks by name

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -88,4 +88,7 @@ terraform import unifi_network.mynetwork 5dc28e5e9106d105bdc87217
 
 # import from another site
 terraform import unifi_network.mynetwork bfa2l6i7:5dc28e5e9106d105bdc87217
+
+# import network by name
+terraform import unifi_network.mynetwork name=LAN
 ```

--- a/examples/resources/unifi_network/import.sh
+++ b/examples/resources/unifi_network/import.sh
@@ -3,3 +3,6 @@ terraform import unifi_network.mynetwork 5dc28e5e9106d105bdc87217
 
 # import from another site
 terraform import unifi_network.mynetwork bfa2l6i7:5dc28e5e9106d105bdc87217
+
+# import network by name
+terraform import unifi_network.mynetwork name=LAN

--- a/internal/provider/lazy_client.go
+++ b/internal/provider/lazy_client.go
@@ -113,6 +113,12 @@ func (c *lazyClient) GetNetwork(ctx context.Context, site, id string) (*unifi.Ne
 	}
 	return c.inner.GetNetwork(ctx, site, id)
 }
+func (c *lazyClient) ListNetwork(ctx context.Context, site string) ([]unifi.Network, error) {
+	if err := c.init(ctx); err != nil {
+		return nil, err
+	}
+	return c.inner.ListNetwork(ctx, site)
+}
 func (c *lazyClient) UpdateNetwork(ctx context.Context, site string, d *unifi.Network) (*unifi.Network, error) {
 	if err := c.init(ctx); err != nil {
 		return nil, err

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -149,6 +149,7 @@ type unifiClient interface {
 	DeleteNetwork(ctx context.Context, site, id, name string) error
 	CreateNetwork(ctx context.Context, site string, d *unifi.Network) (*unifi.Network, error)
 	GetNetwork(ctx context.Context, site, id string) (*unifi.Network, error)
+	ListNetwork(ctx context.Context, site string) ([]unifi.Network, error)
 	UpdateNetwork(ctx context.Context, site string, d *unifi.Network) (*unifi.Network, error)
 
 	DeleteWLAN(ctx context.Context, site, id string) error

--- a/internal/provider/resource_wlan_test.go
+++ b/internal/provider/resource_wlan_test.go
@@ -270,7 +270,7 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
 	vlan_id       = %[1]d
 }
 
@@ -302,7 +302,7 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
 	vlan_id       = %[1]d
 }
 
@@ -331,7 +331,7 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
 	vlan_id       = %[1]d
 }
 
@@ -357,7 +357,7 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
 	vlan_id       = %[1]d
 }
 
@@ -395,7 +395,7 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
 	vlan_id       = %[1]d
 }
 
@@ -425,7 +425,7 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
 	vlan_id       = %[1]d
 }
 
@@ -455,7 +455,7 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 4, %[1]d)
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
 	vlan_id       = %[1]d
 }
 


### PR DESCRIPTION
- E.g. `terraform import unifi_network.mynetwork name=LAN`
- Bumps cidr prefix in tests to avoid:
    Call to function "cidrsubnet" failed: prefix extension of 4 does not
    accommodate a subnet numbered 18.