### PR TITLE
Implement static WAN configuration in unifi_network

### DIFF
--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -316,9 +316,11 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 			wanDNS = append(wanDNS, dns)
 		}
 
-		wanIP = resp.WANIP
-		wanNetmask = resp.WANNetmask
-		wanGateway = resp.WANGateway
+		if wanType != "dhcp" {
+			wanIP = resp.WANIP
+			wanNetmask = resp.WANNetmask
+			wanGateway = resp.WANGateway
+		}
 
 		// TODO: set other wan only fields here?
 	}


### PR DESCRIPTION
When configuring a static WAN, one needs to set not just WAN IP,
but also netmask, gateway, and possibly DNS IPs.

Expose those settings through the unifi_network resource.

Also, ignore them when WAN Type is DHCP, because UniFi controller doesn't allow us to set them to empty.