### PR TITLE
Add `wan_dns1` and `wan_dns2`

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -67,14 +67,14 @@ resource "unifi_network" "wan" {
 - **site** (String) The name of the site to associate the network with.
 - **subnet** (String) The subnet of the network. Must be a valid CIDR address.
 - **vlan_id** (Number) The VLAN ID of the network.
+- **wan_dns1** (String) Primary DNS server for the WAN.
+- **wan_dns2** (String) Secondary DNS server for the WAN.
 - **wan_egress_qos** (Number) Specifies the WAN egress quality of service. Defaults to `0`.
 - **wan_ip** (String) The IPv4 address of the WAN.
 - **wan_networkgroup** (String) Specifies the WAN network group. Must be one of either `WAN`, `WAN2` or `WAN_LTE_FAILOVER`.
 - **wan_type** (String) Specifies the IPV4 WAN connection type. Must be one of either `disabled`, `static`, `dhcp`, or `pppoe`.
 - **wan_username** (String) Specifies the IPV4 WAN username.
 - **x_wan_password** (String) Specifies the IPV4 WAN password.
-- **wan_dns1** (String) The IPv4 address of the primary DNS server for the WAN.
-- **wan_dns2** (String) The IPv4 address of the secondary DNS server for the WAN.
 
 ### Read-Only
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -73,6 +73,8 @@ resource "unifi_network" "wan" {
 - **wan_type** (String) Specifies the IPV4 WAN connection type. Must be one of either `disabled`, `static`, `dhcp`, or `pppoe`.
 - **wan_username** (String) Specifies the IPV4 WAN username.
 - **x_wan_password** (String) Specifies the IPV4 WAN password.
+- **wan_dns1** (String) The IPv4 address of the primary DNS server for the WAN.
+- **wan_dns2** (String) The IPv4 address of the secondary DNS server for the WAN.
 
 ### Read-Only
 

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -189,6 +189,18 @@ func resourceNetwork() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validateWANPassword,
 			},
+			"wan_dns1": {
+				Description:  "Primary DNS server for the WAN.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
+			"wan_dns2": {
+				Description:  "Secondary DNS server for the WAN.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
 		},
 	}
 }
@@ -259,6 +271,8 @@ func resourceNetworkGetResourceData(d *schema.ResourceData) (*unifi.Network, err
 		WANEgressQOS:    d.Get("wan_egress_qos").(int),
 		WANUsername:     d.Get("wan_username").(string),
 		XWANPassword:    d.Get("x_wan_password").(string),
+		WANDNS1:         d.Get("wan_dns1").(string),
+		WANDNS2:         d.Get("wan_dns2").(string),
 	}, nil
 }
 
@@ -318,6 +332,8 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("wan_egress_qos", resp.WANEgressQOS)
 	d.Set("wan_username", resp.WANUsername)
 	d.Set("x_wan_password", resp.XWANPassword)
+	d.Set("wan_dns1", resp.WANDNS1)
+	d.Set("wan_dns2", resp.WANDNS2)
 
 	return nil
 }

--- a/internal/provider/resource_network_test.go
+++ b/internal/provider/resource_network_test.go
@@ -140,7 +140,7 @@ func TestAccNetwork_wan(t *testing.T) {
 		// TODO: CheckDestroy: ,
 		Steps: []resource.TestStep{
 			{
-				Config: testWanNetworkConfig("WAN", "pppoe", "192.168.1.1", 1, "username", "password"),
+				Config: testWanNetworkConfig("WAN", "pppoe", "192.168.1.1", 1, "username", "password", "8.8.8.8", "4.4.4.4"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_networkgroup", "WAN"),
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_type", "pppoe"),
@@ -148,11 +148,13 @@ func TestAccNetwork_wan(t *testing.T) {
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_egress_qos", "1"),
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_username", "username"),
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "x_wan_password", "password"),
+					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_dns1", "8.8.8.8"),
+					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_dns2", "4.4.4.4"),
 				),
 			},
 			importStep("unifi_network.wan_test"),
 			{
-				Config: testWanNetworkConfig("WAN", "pppoe", "192.168.1.1", 1, "username", "password"),
+				Config: testWanNetworkConfig("WAN", "pppoe", "192.168.1.1", 1, "username", "password", "8.8.8.8", "4.4.4.4"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_networkgroup", "WAN"),
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_type", "pppoe"),
@@ -160,6 +162,8 @@ func TestAccNetwork_wan(t *testing.T) {
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_egress_qos", "1"),
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_username", "username"),
 					resource.TestCheckResourceAttr("unifi_network.wan_test", "x_wan_password", "password"),
+					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_dns1", "8.8.8.8"),
+					resource.TestCheckResourceAttr("unifi_network.wan_test", "wan_dns2", "4.4.4.4"),
 				),
 			},
 			importStep("unifi_network.wan_test"),
@@ -262,7 +266,7 @@ resource "unifi_network" "test" {
 `, vlan, ipv6Type, ipv6Subnet)
 }
 
-func testWanNetworkConfig(networkGroup string, wanType string, wanIP string, wanEgressQOS int, wanUsername string, wanPassword string) string {
+func testWanNetworkConfig(networkGroup string, wanType string, wanIP string, wanEgressQOS int, wanUsername string, wanPassword string, wanDNS1 string, wanDNS2 string) string {
 	return fmt.Sprintf(`
 resource "unifi_network" "wan_test" {
 	name    = "tfwan"
@@ -273,8 +277,10 @@ resource "unifi_network" "wan_test" {
 	wan_egress_qos = %d
 	wan_username = "%s"
 	x_wan_password = "%s"
+	wan_dns1 = "%s"
+	wan_dns2 = "%s"
 }
-`, networkGroup, wanType, wanIP, wanEgressQOS, wanUsername, wanPassword)
+`, networkGroup, wanType, wanIP, wanEgressQOS, wanUsername, wanPassword, wanDNS1, wanDNS2)
 }
 
 func testAccNetworkWithSiteConfig(vlan int) string {


### PR DESCRIPTION
Add new fields to `unifi_network` to allow the DNS servers to be configured for a WAN network.