### PR TITLE
DHCPD Boot Server / Filename

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -45,9 +45,9 @@ jobs:
           - stable-5
           - stable-6
         terraform:
-          - '0.13.6'
-          - '0.14.10'
-          - '0.15.0'
+          - '0.13.7'
+          - '0.14.11'
+          - '0.15.4'
     steps:
 
     - name: Set up Go

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -57,8 +57,8 @@ resource "unifi_network" "wan" {
 - **dhcp_start** (String) The IPv4 address where the DHCP range of addresses starts.
 - **dhcp_stop** (String) The IPv4 address where the DHCP range of addresses stops.
 - **dhcpd_boot_enabled** (Boolean) Toggles on the DHCP boot options. Should be set to true when you want to have dhcpd_boot_filename, and dhcpd_boot_server to take effect.
-- **dhcpd_boot_server** (String) Specifies the IPv4 address of a TFTP server to network boot from.
 - **dhcpd_boot_filename** (String) Specifies the file to PXE boot from on the dhcpd_boot_server.
+- **dhcpd_boot_server** (String) Specifies the IPv4 address of a TFTP server to network boot from.
 - **domain_name** (String) The domain name of this network.
 - **igmp_snooping** (Boolean) Specifies whether IGMP snooping is enabled or not.
 - **ipv6_interface_type** (String) Specifies which type of IPv6 connection to use. Defaults to `none`.

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -56,6 +56,9 @@ resource "unifi_network" "wan" {
 - **dhcp_lease** (Number) Specifies the lease time for DHCP addresses. Defaults to `86400`.
 - **dhcp_start** (String) The IPv4 address where the DHCP range of addresses starts.
 - **dhcp_stop** (String) The IPv4 address where the DHCP range of addresses stops.
+- **dhcpd_boot_enabled** (Boolean) Toggles on the DHCP boot options. Should be set to true when you want to have dhcpd_boot_filename, and dhcpd_boot_server to take effect.
+- **dhcpd_boot_server** (String) Specifies the IPv4 address of a TFTP server to network boot from.
+- **dhcpd_boot_filename** (String) Specifies the file to PXE boot from on the dhcpd_boot_server.
 - **domain_name** (String) The domain name of this network.
 - **igmp_snooping** (Boolean) Specifies whether IGMP snooping is enabled or not.
 - **ipv6_interface_type** (String) Specifies which type of IPv6 connection to use. Defaults to `none`.

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -118,6 +118,21 @@ func resourceNetwork() *schema.Resource {
 					),
 				},
 			},
+			"dhcpd_boot_enabled": {
+				Description: "Toggles on the DHCP boot options. Should be set to true when you want to have dhcpd_boot_filename, and dhcpd_boot_server to take effect.",
+				Type: schema.TypeBool,
+				Optional: true,
+			},
+			"dhcpd_boot_server": {
+				Description: "Specifies the IPv4 address of a TFTP server to network boot from.",
+				Type: schema.TypeString,
+				Optional: true,
+			},
+			"dhcpd_boot_filename": {
+				Description: "Specifies the file to PXE boot from on the dhcpd_boot_server.",
+				Type: schema.TypeString,
+				Optional: true,
+			},
 			"domain_name": {
 				Description: "The domain name of this network.",
 				Type:        schema.TypeString,
@@ -251,17 +266,20 @@ func resourceNetworkGetResourceData(d *schema.ResourceData) (*unifi.Network, err
 	}
 
 	return &unifi.Network{
-		Name:           d.Get("name").(string),
-		Purpose:        d.Get("purpose").(string),
-		VLAN:           vlan,
-		IPSubnet:       cidrOneBased(d.Get("subnet").(string)),
-		NetworkGroup:   d.Get("network_group").(string),
-		DHCPDStart:     d.Get("dhcp_start").(string),
-		DHCPDStop:      d.Get("dhcp_stop").(string),
-		DHCPDEnabled:   d.Get("dhcp_enabled").(bool),
-		DHCPDLeaseTime: d.Get("dhcp_lease").(int),
-		DomainName:     d.Get("domain_name").(string),
-		IGMPSnooping:   d.Get("igmp_snooping").(bool),
+		Name:              d.Get("name").(string),
+		Purpose:           d.Get("purpose").(string),
+		VLAN:              vlan,
+		IPSubnet:          cidrOneBased(d.Get("subnet").(string)),
+		NetworkGroup:      d.Get("network_group").(string),
+		DHCPDStart:        d.Get("dhcp_start").(string),
+		DHCPDStop:         d.Get("dhcp_stop").(string),
+		DHCPDEnabled:      d.Get("dhcp_enabled").(bool),
+		DHCPDLeaseTime:    d.Get("dhcp_lease").(int),
+		DHCPDBootEnabled:  d.Get("dhcpd_boot_enabled").(bool),
+		DHCPDBootServer:   d.Get("dhcpd_boot_server").(string),
+		DHCPDBootFilename: d.Get("dhcpd_boot_filename").(string),
+		DomainName:        d.Get("domain_name").(string),
+		IGMPSnooping:      d.Get("igmp_snooping").(bool),
 
 		DHCPDDNSEnabled: len(dhcpDNS) > 0,
 		// this is kinda hacky but ¯\_(ツ)_/¯
@@ -363,6 +381,9 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("dhcp_stop", resp.DHCPDStop)
 	d.Set("dhcp_enabled", resp.DHCPDEnabled)
 	d.Set("dhcp_lease", dhcpLease)
+	d.Set("dhcpd_boot_enabled", resp.DHCPDBootEnabled)
+	d.Set("dhcpd_boot_server", resp.DHCPDBootServer)
+	d.Set("dhcpd_boot_filename", resp.DHCPDBootFilename)
 	d.Set("domain_name", resp.DomainName)
 	d.Set("igmp_snooping", resp.IGMPSnooping)
 	d.Set("dhcp_dns", dhcpDNS)

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -120,18 +120,19 @@ func resourceNetwork() *schema.Resource {
 			},
 			"dhcpd_boot_enabled": {
 				Description: "Toggles on the DHCP boot options. Should be set to true when you want to have dhcpd_boot_filename, and dhcpd_boot_server to take effect.",
-				Type: schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
 			},
 			"dhcpd_boot_server": {
 				Description: "Specifies the IPv4 address of a TFTP server to network boot from.",
-				Type: schema.TypeString,
+				Type:        schema.TypeString,
+				// TODO: IPv4 validation?
 				Optional: true,
 			},
 			"dhcpd_boot_filename": {
 				Description: "Specifies the file to PXE boot from on the dhcpd_boot_server.",
-				Type: schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 			"domain_name": {
 				Description: "The domain name of this network.",


### PR DESCRIPTION
Allows setting the DHCPD boot server and filename attributes of Networks
to enable PXE booting.