### PR TITLE
Add `dev_id_override` to `unifi_user`

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -38,6 +38,7 @@ resource "unifi_user" "test" {
 
 - **allow_existing** (Boolean) Specifies whether this resource should just take over control of an existing user. Defaults to `true`.
 - **blocked** (Boolean) Specifies whether this user should be blocked from the network.
+- **dev_id_override** (Number) Override the device fingerprint.
 - **fixed_ip** (String) A fixed IPv4 address for this user.
 - **network_id** (String) The network ID for this user.
 - **note** (String) A note with additional information for the user.

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/paultyng/go-unifi v1.18.0
+	github.com/paultyng/go-unifi v1.19.0
 	github.com/posener/complete v1.2.1 // indirect
 	golang.org/x/tools v0.0.0-20201017001424-6003fad69a88 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/paultyng/go-unifi v1.18.0 h1:8QDNQi8g6TYg+k86We8cdWvdIRF9rh7qnjcfNUTrSM4=
-github.com/paultyng/go-unifi v1.18.0/go.mod h1:8UZxH9XvrxcIWI6H/jtLyziMvqFmL85RbTLpWMf7xe4=
+github.com/paultyng/go-unifi v1.19.0 h1:1lsZZ9wwvvzY9/ybAlXwkPNBBwUlO7Fr4aXJJ2ioRjI=
+github.com/paultyng/go-unifi v1.19.0/go.mod h1:8UZxH9XvrxcIWI6H/jtLyziMvqFmL85RbTLpWMf7xe4=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/provider/lazy_client.go
+++ b/internal/provider/lazy_client.go
@@ -245,6 +245,12 @@ func (c *lazyClient) UnblockUserByMAC(ctx context.Context, site, mac string) err
 	}
 	return c.inner.UnblockUserByMAC(ctx, site, mac)
 }
+func (c *lazyClient) OverrideUserFingerprint(ctx context.Context, site, mac string, devIdOveride int) error {
+	if err := c.init(ctx); err != nil {
+		return err
+	}
+	return c.inner.OverrideUserFingerprint(ctx, site, mac, devIdOveride)
+}
 func (c *lazyClient) ListFirewallGroup(ctx context.Context, site string) ([]unifi.FirewallGroup, error) {
 	if err := c.init(ctx); err != nil {
 		return nil, err

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -174,6 +174,7 @@ type unifiClient interface {
 	UnblockUserByMAC(ctx context.Context, site, mac string) error
 	UpdateUser(ctx context.Context, site string, d *unifi.User) (*unifi.User, error)
 	DeleteUserByMAC(ctx context.Context, site, mac string) error
+	OverrideUserFingerprint(ctx context.Context, site, mac string, devIdOveride int) error
 
 	GetPortForward(ctx context.Context, site, id string) (*unifi.PortForward, error)
 	DeletePortForward(ctx context.Context, site, id string) error


### PR DESCRIPTION
Allow device fingerprints to be overriden. Depends on paultyng/go-unifi#38.