### PR TITLE
Add minimum_data_rate_2g and minimum_data_rate_5g fields to unifi_wlan

### DIFF
--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -67,8 +67,8 @@ resource "unifi_wlan" "wifi" {
 - **mac_filter_enabled** (Boolean) Indicates whether or not the MAC filter is turned of for the network.
 - **mac_filter_list** (Set of String) List of MAC addresses to filter (only valid if `mac_filter_enabled` is `true`).
 - **mac_filter_policy** (String) MAC address filter policy (only valid if `mac_filter_enabled` is `true`). Defaults to `deny`.
-- **minimum_data_rate_2g** (String) Enable minimum data rate control for 2G devices
-- **minimum_data_rate_5g** (String) Enable minimum data rate control for 5G devices
+- **minimum_data_rate_2g_kbps** (Number) Set minimum data rate control for 2G devices, in Kbps. Use `0` to disable minimum data rates. Valid values are: `1000`, `2000`, `5500`, `6000`, `9000`, `11000`, `12000`, `18000`, `24000`, `36000`, `48000`,  and `54000`.
+- **minimum_data_rate_5g_kbps** (Number) Set minimum data rate control for 5G devices, in Kbps. Use `0` to disable minimum data rates. Valid values are: `6000`, `9000`, `12000`, `18000`, `24000`, `36000`, `48000`,  and `54000`.
 - **multicast_enhance** (Boolean) Indicates whether or not Multicast Enhance is turned of for the network.
 - **network_id** (String) ID of the network for this SSID
 - **no2ghz_oui** (Boolean) Connect high performance clients to 5 GHz only Defaults to `true`.

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -67,6 +67,8 @@ resource "unifi_wlan" "wifi" {
 - **mac_filter_enabled** (Boolean) Indicates whether or not the MAC filter is turned of for the network.
 - **mac_filter_list** (Set of String) List of MAC addresses to filter (only valid if `mac_filter_enabled` is `true`).
 - **mac_filter_policy** (String) MAC address filter policy (only valid if `mac_filter_enabled` is `true`). Defaults to `deny`.
+- **minimum_data_rate_2g** (String) Enable minimum data rate control for 2G devices
+- **minimum_data_rate_5g** (String) Enable minimum data rate control for 5G devices
 - **multicast_enhance** (Boolean) Indicates whether or not Multicast Enhance is turned of for the network.
 - **network_id** (String) ID of the network for this SSID
 - **no2ghz_oui** (Boolean) Connect high performance clients to 5 GHz only Defaults to `true`.

--- a/internal/provider/markdown.go
+++ b/internal/provider/markdown.go
@@ -1,0 +1,19 @@
+package provider
+
+import "strconv"
+
+func markdownValueListInt(values []int) string {
+	switch {
+	case len(values) == 0:
+		return ""
+	case len(values) == 1:
+		return "`" + strconv.Itoa(values[0]) + "`"
+	default:
+		s := ""
+		for i := 0; i < len(values)-1; i++ {
+			s += "`" + strconv.Itoa(values[i]) + "`, "
+		}
+		s += " and `" + strconv.Itoa(values[len(values)-1]) + "`"
+		return s
+	}
+}

--- a/internal/provider/resource_wlan.go
+++ b/internal/provider/resource_wlan.go
@@ -424,8 +424,16 @@ func resourceWLANSetResourceData(resp *unifi.WLAN, d *schema.ResourceData, meta 
 	d.Set("no2ghz_oui", resp.No2GhzOui)
 	d.Set("l2_isolation", resp.L2Isolation)
 	d.Set("uapsd", resp.UapsdEnabled)
-	d.Set("minimum_data_rate_2g_kbps", resp.MinrateNgDataRateKbps)
-	d.Set("minimum_data_rate_5g_kbps", resp.MinrateNaDataRateKbps)
+	if resp.MinrateNgEnabled {
+		d.Set("minimum_data_rate_2g_kbps", resp.MinrateNgDataRateKbps)
+	} else {
+		d.Set("minimum_data_rate_2g_kbps", 0)
+	}
+	if resp.MinrateNaEnabled {
+		d.Set("minimum_data_rate_5g_kbps", resp.MinrateNaDataRateKbps)
+	} else {
+		d.Set("minimum_data_rate_5g_kbps", 0)
+	}
 
 	// switch v := c.ControllerVersion(); {
 	// case v.GreaterThanOrEqual(controllerV6):

--- a/internal/provider/resource_wlan_test.go
+++ b/internal/provider/resource_wlan_test.go
@@ -327,6 +327,33 @@ func TestAccWLAN_wpa3(t *testing.T) {
 	})
 }
 
+func TestAccWLAN_minimum_data_rate(t *testing.T) {
+	vlanID := getTestVLAN(t)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			preCheck(t)
+			preCheckV6Only(t)
+			wlanPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			// TODO: actual CheckDestroy
+
+			<-wlanConcurrency
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWLANConfig_minimum_data_rate(vlanID),
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
+		},
+	})
+}
+
 func testAccWLANConfig_wpapsk(vlanID int) string {
 	return fmt.Sprintf(`
 data "unifi_ap_group" "default" {
@@ -598,4 +625,35 @@ resource "unifi_wlan" "test" {
 	wpa3_transition = %[2]t
 }
 `, vlanID, wpa3Transition)
+}
+
+func testAccWLANConfig_minimum_data_rate(vlanID int) string {
+	return fmt.Sprintf(`
+data "unifi_ap_group" "default" {
+}
+
+data "unifi_user_group" "default" {
+}
+
+resource "unifi_network" "test" {
+	name    = "tfacc"
+	purpose = "corporate"
+
+	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
+	vlan_id       = %[1]d
+}
+
+resource "unifi_wlan" "test" {
+	name          = "tfacc-wpapsk"
+	network_id    = unifi_network.test.id
+	passphrase    = "12345678"
+	ap_group_ids = [data.unifi_ap_group.default.id]
+	user_group_id = data.unifi_user_group.default.id
+	security      = "wpapsk"
+	multicast_enhance = true
+
+	minimum_data_rate_2g = "5.5Mbps"
+	minimum_data_rate_5g = "18Mbps"
+}
+`, vlanID)
 }

--- a/internal/provider/resource_wlan_test.go
+++ b/internal/provider/resource_wlan_test.go
@@ -344,7 +344,28 @@ func TestAccWLAN_minimum_data_rate(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWLANConfig_minimum_data_rate(vlanID),
+				Config: testAccWLANConfig_minimum_data_rate(vlanID, 5500, 18000),
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
+			{
+				Config: testAccWLANConfig_minimum_data_rate(vlanID, 0, 18000),
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
+			{
+				Config: testAccWLANConfig_minimum_data_rate(vlanID, 6000, 0),
+				Check:  resource.ComposeTestCheckFunc(
+				// testCheckNetworkExists(t, "name"),
+				),
+			},
+			importStep("unifi_wlan.test"),
+			{
+				Config: testAccWLANConfig_minimum_data_rate(vlanID, 18000, 6000),
 				Check:  resource.ComposeTestCheckFunc(
 				// testCheckNetworkExists(t, "name"),
 				),
@@ -627,7 +648,7 @@ resource "unifi_wlan" "test" {
 `, vlanID, wpa3Transition)
 }
 
-func testAccWLANConfig_minimum_data_rate(vlanID int) string {
+func testAccWLANConfig_minimum_data_rate(vlanID int, min2g int, min5g int) string {
 	return fmt.Sprintf(`
 data "unifi_ap_group" "default" {
 }
@@ -639,21 +660,22 @@ resource "unifi_network" "test" {
 	name    = "tfacc"
 	purpose = "corporate"
 
-	subnet        = cidrsubnet("10.0.0.0/8", 6, %[1]d)
-	vlan_id       = %[1]d
+	subnet  = cidrsubnet("10.0.0.0/8", 6, %[1]d)
+	vlan_id = %[1]d
 }
 
 resource "unifi_wlan" "test" {
 	name          = "tfacc-wpapsk"
 	network_id    = unifi_network.test.id
 	passphrase    = "12345678"
-	ap_group_ids = [data.unifi_ap_group.default.id]
+	ap_group_ids  = [data.unifi_ap_group.default.id]
 	user_group_id = data.unifi_user_group.default.id
 	security      = "wpapsk"
+
 	multicast_enhance = true
 
-	minimum_data_rate_2g = "5.5Mbps"
-	minimum_data_rate_5g = "18Mbps"
+	minimum_data_rate_2g_kbps = %[2]d
+	minimum_data_rate_5g_kbps = %[3]d
 }
-`, vlanID)
+`, vlanID, min2g, min5g)
 }


### PR DESCRIPTION
This is to enable setting minimum data rates for 2G and 5G devices on a wireless network.

It relates to the following section in the UI:
![Screenshot 2021-07-20 at 15-54-12 UniFi Network](https://user-images.githubusercontent.com/2661907/126259526-79ce96f6-aaa9-4488-8a2f-0e5860e77cb2.png)

The validation on the terraform schema is pulled directly from the UI, I tested a value that is not from the UI and the request failed with status 400.

I am open to suggestion on changing the field names, or potentially using a block instead of a single field so that we can support the other arguments in the future.