### PR TITLE
Put controller into demo mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ export UNIFI_USERNAME ?= tfacctest
 export UNIFI_EMAIL    ?= tfacctest@example.com
 export UNIFI_PASSWORD ?= tfacctest1234
 
-TEST     ?= ./...
-TESTARGS ?=
+TEST       ?= ./...
+TESTARGS   ?=
+TEST_COUNT ?= 1
 
 .PHONY: default
 default: build
@@ -15,7 +16,7 @@ build:
 
 .PHONY: testacc
 testacc:
-	TF_ACC=1 UNIFI_ACC_WLAN_CONCURRENCY=4 UNIFI_API=https://localhost:8443 UNIFI_INSECURE=true go test $(TEST) -v $(TESTARGS)
+	TF_ACC=1 UNIFI_ACC_WLAN_CONCURRENCY=3 UNIFI_API=https://localhost:8443 UNIFI_INSECURE=true go test $(TEST) -v -count=$(TEST_COUNT) $(TESTARGS)
 
 .PHONY: testacc-up
 testacc-up:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
     ports:
       - '${UNIFI_HTTP_PORT:-8080}:8080/tcp'
       - '${UNIFI_HTTPS_PORT:-8443}:8443/tcp'
+    volumes:
+      - './scripts/init.d:/usr/local/unifi/init.d:ro'
 
   bootstrap:
     image: 'alpine/httpie'

--- a/scripts/init.d/demo-mode
+++ b/scripts/init.d/demo-mode
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+write_config() {
+  echo "${1}=${2}" >> /usr/lib/unifi/data/system.properties
+}
+
+write_config demo.skip_wizard false
+write_config is_simulation true


### PR DESCRIPTION
Puts the Unifi controller for acceptance testing into demo mode, similar to https://demo.ui.com/ (which doesn't seem to be working at the moment). There are a bunch of other demo-related settings I found, which I haven't implemented but will document here.

- `demo.username` and `demo.password` seem to enable auto-login functionality.
- `demo.num_uap`, `demo.num_usw` and `demo.num_ugw` set the number of test devices.
- I couldn't work out what `demo.mode` or `demo.passthrough.secret` does.

The test devices seem to have incrementing MAC addresses. Switches start at `
00:27:22:00:00:01`, gateways start at `
dc:9f:db:00:00:01` and access points start at `
00:15:6d:00:00:01`.

I want to figure out a way to either automatically adopt all of the test devices or create some sort of adoption resource for the Terraform provider. But once the devices are adopted, they seem to work as expected.

I had to reduce `UNIFI_ACC_WLAN_CONCURRENCY` from `4` to `3` as the demo site already has a single WLAN configured. Otherwise, this error occurs:

```
=== CONT  TestAccWLAN_no2ghz_oui
    resource_wlan_test.go:236: Step 1/2 error: Error running apply: exit status 1
        
        Error: api.err.TooManyWirelessNetwork (400 ) for POST https://localhost:8443/api/s/default/rest/wlanconf
        
          with unifi_wlan.test,
          on terraform_plugin_test.tf line 16, in resource "unifi_wlan" "test":
          16: resource "unifi_wlan" "test" {
```