### PR TITLE
Add `setup-go` before `golangci-lint`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,4 +31,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
+      - uses: "actions/setup-go@v3"
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - uses: "golangci/golangci-lint-action@v3.1.0"


### PR DESCRIPTION
Version 3 of `golangci/golangci-lint-action` requires explicit `setup-go` installation.