### PR TITLE
unifi_port_forward enabled should default to true

### DIFF
--- a/internal/provider/resource_port_forward.go
+++ b/internal/provider/resource_port_forward.go
@@ -44,6 +44,7 @@ func resourcePortForward() *schema.Resource {
 			"enabled": {
 				Description: "Specifies whether the port forwarding rule is enabled or not.",
 				Type:        schema.TypeBool,
+				Default:     true,
 				Optional:    true,
 				Deprecated: "This will attribute will be removed in a future release. Instead of disabling a " +
 					"port forwarding rule you can remove it from your configuration.",


### PR DESCRIPTION
Port forwards are created with `enabled = false` currently, with no way to actually enable them via terraform since `enabled` is deprecated 

Fixes https://github.com/paultyng/terraform-provider-unifi/issues/255