### PR TITLE
Support access options in Unifi network payload

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -62,6 +62,8 @@ resource "unifi_network" "wan" {
 - `dhcpd_boot_server` (String) Specifies the IPv4 address of a TFTP server to network boot from.
 - `domain_name` (String) The domain name of this network.
 - `igmp_snooping` (Boolean) Specifies whether IGMP snooping is enabled or not.
+- `internet_access_enabled` (Boolean) Specifies whether this network should be allowed to access the internet or not. Defaults to `true`.
+- `intra_network_access_enabled` (Boolean) Specifies whether this network should be allowed to access other local networks or not. Defaults to `true`.
 - `ipv6_interface_type` (String) Specifies which type of IPv6 connection to use. Defaults to `none`.
 - `ipv6_pd_interface` (String) Specifies which WAN interface to use for IPv6 PD.
 - `ipv6_pd_prefixid` (String) Specifies the IPv6 Prefix ID.

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -176,6 +176,18 @@ func resourceNetwork() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
+			"internet_access_enabled": {
+				Description: "Specifies whether this network should be allowed to access the internet or not.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
+			"intra_network_access_enabled": {
+				Description: "Specifies whether this network should be allowed to access other local networks or not.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
 			"wan_ip": {
 				Description:  "The IPv4 address of the WAN.",
 				Type:         schema.TypeString,
@@ -308,6 +320,9 @@ func resourceNetworkGetResourceData(d *schema.ResourceData, meta interface{}) (*
 		IPV6PDPrefixid:    d.Get("ipv6_pd_prefixid").(string),
 		IPV6RaEnabled:     d.Get("ipv6_ra_enable").(bool),
 
+		InternetAccessEnabled:     d.Get("internet_access_enabled").(bool),
+		IntraNetworkAccessEnabled: d.Get("intra_network_access_enabled").(bool),
+
 		WANIP:           d.Get("wan_ip").(string),
 		WANType:         d.Get("wan_type").(string),
 		WANNetmask:      d.Get("wan_netmask").(string),
@@ -403,6 +418,8 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("ipv6_pd_interface", resp.IPV6PDInterface)
 	d.Set("ipv6_pd_prefixid", resp.IPV6PDPrefixid)
 	d.Set("ipv6_ra_enable", resp.IPV6RaEnabled)
+	d.Set("internet_access_enabled", resp.InternetAccessEnabled)
+	d.Set("intra_network_access_enabled", resp.IntraNetworkAccessEnabled)
 	d.Set("wan_ip", wanIP)
 	d.Set("wan_netmask", wanNetmask)
 	d.Set("wan_gateway", wanGateway)


### PR DESCRIPTION
See #279. These options were always being set to false, which caused Unifi to block internet access.

I'm not 100% sure what effect these have on the WAN networks, and they're getting applied there as well. It doesn't seem to change anything. I think ideally though these would be empty in the payload, which is how the Unifi console creates networks (both WAN and LAN).