### PR TITLE
Add support for mDNS on network resource

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -64,6 +64,7 @@ data "unifi_network" "my_network" {
 - `ipv6_ra_priority` (String) IPv6 router advertisement priority. Must be one of either `high`, `medium`, or `low`
 - `ipv6_ra_valid_lifetime` (Number) Total lifetime in which the address can be used. Must be equal to or greater than `ipv6_ra_preferred_lifetime`.
 - `ipv6_static_subnet` (String) Specifies the static IPv6 subnet (when ipv6_interface_type is 'static').
+- `multicast_dns` (Boolean) Specifies whether Multicast DNS (mDNS) is enabled or not on the network (Controller >=v7).
 - `network_group` (String) The group of the network.
 - `purpose` (String) The purpose of the network. One of `corporate`, `guest`, `wan`, or `vlan-only`.
 - `subnet` (String) The subnet of the network (CIDR address).

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -80,6 +80,7 @@ resource "unifi_network" "wan" {
 - `ipv6_ra_priority` (String) IPv6 router advertisement priority. Must be one of either `high`, `medium`, or `low`
 - `ipv6_ra_valid_lifetime` (Number) Total lifetime in which the address can be used. Must be equal to or greater than `ipv6_ra_preferred_lifetime`. Defaults to `86400`.
 - `ipv6_static_subnet` (String) Specifies the static IPv6 subnet when `ipv6_interface_type` is 'static'.
+- `multicast_dns` (Boolean) Specifies whether Multicast DNS (mDNS) is enabled or not on the network (Controller >=v7).
 - `network_group` (String) The group of the network. Defaults to `LAN`.
 - `site` (String) The name of the site to associate the network with.
 - `subnet` (String) The subnet of the network. Must be a valid CIDR address.

--- a/internal/provider/data_network.go
+++ b/internal/provider/data_network.go
@@ -196,6 +196,11 @@ func dataNetwork() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 			},
+			"multicast_dns": {
+				Description: "Specifies whether Multicast DNS (mDNS) is enabled or not on the network (Controller >=v7).",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
 			"wan_ip": {
 				Description: "The IPv4 address of the WAN.",
 				Type:        schema.TypeString,
@@ -324,6 +329,7 @@ func dataNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface
 			d.Set("vlan_id", n.VLAN)
 			d.Set("subnet", cidrZeroBased(n.IPSubnet))
 			d.Set("network_group", n.NetworkGroup)
+			d.Set("dhcp_dns", dhcpDNS)
 			d.Set("dhcp_start", n.DHCPDStart)
 			d.Set("dhcp_stop", n.DHCPDStop)
 			d.Set("dhcp_enabled", n.DHCPDEnabled)
@@ -333,12 +339,12 @@ func dataNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface
 			d.Set("dhcpd_boot_filename", n.DHCPDBootFilename)
 			d.Set("domain_name", n.DomainName)
 			d.Set("igmp_snooping", n.IGMPSnooping)
-			d.Set("dhcp_dns", dhcpDNS)
 			d.Set("ipv6_interface_type", n.IPV6InterfaceType)
 			d.Set("ipv6_static_subnet", n.IPV6Subnet)
 			d.Set("ipv6_pd_interface", n.IPV6PDInterface)
 			d.Set("ipv6_pd_prefixid", n.IPV6PDPrefixid)
 			d.Set("ipv6_ra_enable", n.IPV6RaEnabled)
+			d.Set("multicast_dns", n.MdnsEnabled)
 			d.Set("wan_ip", n.WANIP)
 			d.Set("wan_netmask", n.WANNetmask)
 			d.Set("wan_gateway", n.WANGateway)

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -277,6 +277,11 @@ func resourceNetwork() *schema.Resource {
 				Optional:    true,
 				Default:     86400,
 			},
+			"multicast_dns": {
+				Description: "Specifies whether Multicast DNS (mDNS) is enabled or not on the network (Controller >=v7).",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 			"wan_ip": {
 				Description:  "The IPv4 address of the WAN.",
 				Type:         schema.TypeString,
@@ -425,6 +430,7 @@ func resourceNetworkGetResourceData(d *schema.ResourceData, meta interface{}) (*
 		DHCPRelayEnabled:  d.Get("dhcp_relay_enabled").(bool),
 		DomainName:        d.Get("domain_name").(string),
 		IGMPSnooping:      d.Get("igmp_snooping").(bool),
+		MdnsEnabled:       d.Get("multicast_dns").(bool),
 
 		DHCPDDNSEnabled: len(dhcpDNS) > 0,
 		// this is kinda hacky but ¯\_(ツ)_/¯
@@ -591,6 +597,7 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("ipv6_ra_priority", resp.IPV6RaPriority)
 	d.Set("ipv6_ra_valid_lifetime", resp.IPV6RaValidLifetime)
 	d.Set("ipv6_static_subnet", resp.IPV6Subnet)
+	d.Set("multicast_dns", resp.MdnsEnabled)
 	d.Set("wan_dhcp_v6_pd_size", resp.WANDHCPv6PDSize)
 	d.Set("wan_dns", wanDNS)
 	d.Set("wan_egress_qos", resp.WANEgressQOS)


### PR DESCRIPTION
Hi!

First of all, I want to thank you for creating this awesome provider... In combination with Terraform cloud, my home network has gone to the next level :rocket:. Many thanks :)

On Controller `v7`, mDNS was removed (#241) as a global setting and added into each of the networks independently.

![Screenshot_20221109_150809](https://user-images.githubusercontent.com/128204/200867832-69ece245-92a4-43cb-9c68-9082381551d9.png)

This PR adds the setting with a note that it's only supported on controllers `>=v7`.

Note: At first I added unit tests, but it started to get complex because this setting is not supported in all controller versions, also testing every single setting would make the tests hard to read and maintain, so I didn't add a test just for this small setting. If you think it's worth it, I can add the unit test.