### PR TITLE
Add support for local_dns_record

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -37,6 +37,7 @@ data "unifi_user" "client" {
 - `hostname` (String) The hostname of the user.
 - `id` (String) The ID of the user.
 - `ip` (String) The IP address of the user.
+- `local_dns_record` (String) The local DNS record for this user.
 - `name` (String) The name of the user.
 - `network_id` (String) The network ID for this user.
 - `note` (String) A note with additional information for the user.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -40,6 +40,7 @@ resource "unifi_user" "test" {
 - `blocked` (Boolean) Specifies whether this user should be blocked from the network.
 - `dev_id_override` (Number) Override the device fingerprint.
 - `fixed_ip` (String) A fixed IPv4 address for this user.
+- `local_dns_record` (String) Specifies the local DNS record for this user.
 - `network_id` (String) The network ID for this user.
 - `note` (String) A note with additional information for the user.
 - `site` (String) The name of the site to associate the user with.

--- a/internal/provider/data_user.go
+++ b/internal/provider/data_user.go
@@ -81,6 +81,11 @@ func dataUser() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"local_dns_record": {
+				Description: "The local DNS record for this user.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -111,6 +116,10 @@ func dataUserRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 	if resp.UseFixedIP {
 		fixedIP = resp.FixedIP
 	}
+	localDnsRecord := ""
+	if resp.LocalDNSRecordEnabled {
+		localDnsRecord = resp.LocalDNSRecord
+	}
 	d.SetId(resp.ID)
 	d.Set("site", site)
 	d.Set("mac", resp.MAC)
@@ -123,6 +132,7 @@ func dataUserRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 	d.Set("dev_id_override", resp.DevIdOverride)
 	d.Set("hostname", resp.Hostname)
 	d.Set("ip", resp.IP)
+	d.Set("ip", localDnsRecord)
 
 	return nil
 }

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -83,6 +83,11 @@ func resourceUser() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},
+			"local_dns_record": {
+				Description: "Specifies the local DNS record for this user.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 
 			// these are "meta" attributes that control TF UX
 			"allow_existing": {
@@ -177,15 +182,18 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 func resourceUserGetResourceData(d *schema.ResourceData) (*unifi.User, error) {
 	fixedIP := d.Get("fixed_ip").(string)
+	localDnsRecord := d.Get("local_dns_record").(string)
 
 	return &unifi.User{
-		MAC:         d.Get("mac").(string),
-		Name:        d.Get("name").(string),
-		UserGroupID: d.Get("user_group_id").(string),
-		Note:        d.Get("note").(string),
-		FixedIP:     fixedIP,
-		UseFixedIP:  fixedIP != "",
-		NetworkID:   d.Get("network_id").(string),
+		MAC:                   d.Get("mac").(string),
+		Name:                  d.Get("name").(string),
+		UserGroupID:           d.Get("user_group_id").(string),
+		Note:                  d.Get("note").(string),
+		FixedIP:               fixedIP,
+		UseFixedIP:            fixedIP != "",
+		LocalDNSRecord:        localDnsRecord,
+		LocalDNSRecordEnabled: localDnsRecord != "",
+		NetworkID:             d.Get("network_id").(string),
 		// not sure if this matters/works
 		Blocked:       d.Get("blocked").(bool),
 		DevIdOverride: d.Get("dev_id_override").(int),
@@ -198,12 +206,18 @@ func resourceUserSetResourceData(resp *unifi.User, d *schema.ResourceData, site 
 		fixedIP = resp.FixedIP
 	}
 
+	localDnsRecord := ""
+	if resp.LocalDNSRecordEnabled {
+		localDnsRecord = resp.LocalDNSRecord
+	}
+
 	d.Set("site", site)
 	d.Set("mac", resp.MAC)
 	d.Set("name", resp.Name)
 	d.Set("user_group_id", resp.UserGroupID)
 	d.Set("note", resp.Note)
 	d.Set("fixed_ip", fixedIP)
+	d.Set("local_dns_record", localDnsRecord)
 	d.Set("network_id", resp.NetworkID)
 	d.Set("blocked", resp.Blocked)
 	d.Set("dev_id_override", resp.DevIdOverride)


### PR DESCRIPTION
Supports creating `local_dns_record` entries, added in https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65