### PR TITLE
Set default wlan band to 'both'

### DIFF
--- a/internal/provider/resource_wlan.go
+++ b/internal/provider/resource_wlan.go
@@ -203,6 +203,7 @@ func resourceWLAN() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"2g", "5g", "both"}, false),
+				Default:      "both",
 			},
 			"network_id": {
 				Description: "ID of the network for this SSID",


### PR DESCRIPTION
The default was left empty for v5 compatibility, but now that that's been dropped it should default to "both" as per https://github.com/paultyng/terraform-provider-unifi/pull/106#pullrequestreview-605341859.