### PR TITLE
Enable `$LOTSOFDEVICES`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     init: true
     restart: "always"
     user: "unifi"
+    environment:
+      LOTSOFDEVICES: "true"
     ports:
       - "${UNIFI_HTTP_PORT:-8080}:8080/tcp"
       - "${UNIFI_HTTPS_PORT:-8443}:8443/tcp"


### PR DESCRIPTION
From https://hub.docker.com/r/jacobalberty/unifi:

> Enable this with `true` if you run a system with a lot of devices and/or with a low powered system (like a Raspberry Pi). This makes a few adjustments to try and improve performance:
>
> - enable `unifi.G1GC.enabled`
> - set `unifi.xms` to `JVM_INIT_HEAP_SIZE`
> - set `unifi.xmx` to `JVM_MAX_HEAP_SIZE`
> - enable `unifi.db.nojournal`
> - set `unifi.dg.extraargs` to `--quiet`