### PR TITLE
Limit number of demo devices

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     init: true
     restart: "always"
     user: "unifi"
+    environment:
+      UNIFI_STDOUT: "true"
     ports:
       - "${UNIFI_HTTP_PORT:-8080}:8080/tcp"
       - "${UNIFI_HTTPS_PORT:-8443}:8443/tcp"

--- a/scripts/init.d/demo-mode
+++ b/scripts/init.d/demo-mode
@@ -7,6 +7,6 @@ write_config() {
 write_config is_simulation true
 
 # Increase the number of demo devices to allow more concurrent tests to be executed simultaneously.
-write_config demo.num_uap 20
-write_config demo.num_ugw 20
+write_config demo.num_uap 0
+write_config demo.num_ugw 0
 write_config demo.num_usw 20


### PR DESCRIPTION
We currently only need switches for the acceptance tests, so don't provision any access points or gateways.