### PR TITLE
Performance tuning for acceptance tests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,9 @@ services:
     restart: "always"
     user: "unifi"
     environment:
+      JVM_INIT_HEAP_SIZE: "2g"
+      JVM_MAX_HEAP_SIZE: "2g"
+      LOTSOFDEVICES: "true"
       UNIFI_STDOUT: "true"
     ports:
       - "${UNIFI_HTTP_PORT:-8080}:8080/tcp"


### PR DESCRIPTION
Attempting to fix deadlock:

```
[2023-03-01T01:38:21,255] <device-state-check> WARN  monitor - Skipping check for 00:15:6d:00:00:0d, could not acquire lock
com.ubnt.service.lock.D: Failed to acquire lock before timeout
	at com.ubnt.service.lock.B.Ô00000(Unknown Source) ~[ace.jar:?]
	at com.ubnt.service.lock.ooOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO.Ò00000(Unknown Source) ~[ace.jar:?]
	at com.ubnt.service.lock.OooO.while(Unknown Source) ~[ace.jar:?]
	at com.ubnt.service.lock.OooO.OO0000(Unknown Source) ~[ace.jar:?]
	at com.ubnt.service.lock.OooO.õO0000(Unknown Source) ~[ace.jar:?]
	at com.ubnt.service.devmgr.I.Ø00000(Unknown Source) ~[ace.jar:?]
	at com.ubnt.service.devmgr.WA.oO0000(Unknown Source) ~[ace.jar:?]
	at com.ubnt.service.devmgr.WA.Ø00000(Unknown Source) ~[ace.jar:?]
	at com.ubnt.ace.C$_OOo.run(Unknown Source) ~[ace.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

From https://hub.docker.com/r/jacobalberty/unifi:

> Enable this with `true` if you run a system with a lot of devices and/or with a low powered system (like a Raspberry Pi). This makes a few adjustments to try and improve performance:
>
> - enable `unifi.G1GC.enabled`
> - set `unifi.xms` to `JVM_INIT_HEAP_SIZE`
> - set `unifi.xmx` to `JVM_MAX_HEAP_SIZE`
> - enable `unifi.db.nojournal`
> - set `unifi.dg.extraargs` to `--quiet`

See also https://help.ui.com/hc/en-us/articles/115005159588-UniFi-How-to-Tune-the-Network-Application-for-High-Number-of-UniFi-Devices.