### PR TITLE
Revert "Enable `$LOTSOFDEVICES` (#325)"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,9 +6,6 @@ services:
     restart: "always"
     user: "unifi"
     environment:
-      JVM_INIT_HEAP_SIZE: "2g"
-      JVM_MAX_HEAP_SIZE: "2g"
-      LOTSOFDEVICES: "true"
       UNIFI_STDOUT: "true"
     ports:
       - "${UNIFI_HTTP_PORT:-8080}:8080/tcp"


### PR DESCRIPTION
This reverts commit 38dd4b881f44658d0adfa69d2934e77f86a35cc3. This seems to be causing consistency issues, see https://github.com/paultyng/terraform-provider-unifi/actions/runs/4300078164/jobs/7495937646