### PR TITLE
Don't use USW-Leaf in acceptance tests

### DIFF
--- a/internal/provider/resource_device_test.go
+++ b/internal/provider/resource_device_test.go
@@ -44,6 +44,11 @@ func allocateDevice(t *testing.T) (string, func()) {
 					continue
 				}
 
+				// The USW-Leaf is an EOL product and consistently fails to be adopted.
+				if device.Model == "UDC48X6" {
+					continue
+				}
+
 				d := device
 				if ok := devicePool.Add(&d); !ok {
 					return resource.NonRetryableError(fmt.Errorf("Failed to add device to pool"))


### PR DESCRIPTION
The USW-Leaf consistently fails to be adopted:

```
[2023-03-03T04:25:11,002] XXX <fake-UDC48X6> ERROR inform - dev[00:27:22:00:00:12] failed to update capability: api.err.InvalidReportPort
[2023-03-03T04:25:21,004] XXX <fake-UDC48X6> ERROR inform - dev[00:27:22:00:00:12] failed to update capability: api.err.InvalidReportPort
[2023-03-03T04:25:31,005] XXX <fake-UDC48X6> ERROR inform - dev[00:27:22:00:00:12] failed to update capability: api.err.InvalidReportPort
[2023-03-03T04:25:41,006] XXX <fake-UDC48X6> ERROR inform - dev[00:27:22:00:00:12] failed to update capability: api.err.InvalidReportPort
```