### PR TITLE
Increase `golangci-lint` timeout to 5m

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,4 +16,4 @@ linters:
     - "unused"
 
 run:
-  timeout: '2m'
+  timeout: '5m'


### PR DESCRIPTION
See https://github.com/paultyng/terraform-provider-unifi/actions/runs/4368914426/jobs/7642099956.