### PR TITLE
Provision a gateway device for acceptance tests

### DIFF
--- a/scripts/init.d/demo-mode
+++ b/scripts/init.d/demo-mode
@@ -8,5 +8,5 @@ write_config is_simulation true
 
 # Increase the number of demo devices to allow more concurrent tests to be executed simultaneously.
 write_config demo.num_uap 0
-write_config demo.num_ugw 0
+write_config demo.num_ugw 1
 write_config demo.num_usw 20


### PR DESCRIPTION
We don't strictly need a gateway, but it makes it easier to poke around the UI.