### PR TITLE
Support per-port PoE mode override for devices.

### DIFF
--- a/internal/provider/resource_device.go
+++ b/internal/provider/resource_device.go
@@ -98,6 +98,12 @@ func resourceDevice() *schema.Resource {
 								return false
 							},
 						},
+						"poe_mode": {
+							Description: "PoE mode of the port; valid values are `auto`, `pasv24`, `passthrough`, and `off`.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"auto", "pasv24", "passthrough", "off"}, false),
+						},
 						"aggregate_num_ports": {
 							Description:  "Number of ports in the aggregate.",
 							Type:         schema.TypeInt,
@@ -356,6 +362,7 @@ func toPortOverride(data map[string]interface{}) (unifi.DevicePortOverrides, err
 	name := data["name"].(string)
 	profileID := data["port_profile_id"].(string)
 	opMode := data["op_mode"].(string)
+	poeMode := data["poe_mode"].(string)
 	aggregateNumPorts := data["aggregate_num_ports"].(int)
 
 	return unifi.DevicePortOverrides{
@@ -363,6 +370,7 @@ func toPortOverride(data map[string]interface{}) (unifi.DevicePortOverrides, err
 		Name:              name,
 		PortProfileID:     profileID,
 		OpMode:            opMode,
+		PoeMode:           poeMode,
 		AggregateNumPorts: aggregateNumPorts,
 	}, nil
 }
@@ -373,6 +381,7 @@ func fromPortOverride(po unifi.DevicePortOverrides) (map[string]interface{}, err
 		"name":                po.Name,
 		"port_profile_id":     po.PortProfileID,
 		"op_mode":             po.OpMode,
+		"poe_mode":            po.PoeMode,
 		"aggregate_num_ports": po.AggregateNumPorts,
 	}, nil
 }

--- a/internal/provider/resource_device_test.go
+++ b/internal/provider/resource_device_test.go
@@ -262,7 +262,7 @@ func TestAccDevice_switch_portOverrides(t *testing.T) {
 				Config: testAccDeviceConfig_withPortOverrides(device.MAC),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "port_override.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "port_override.#", "4"),
 
 					// TODO: Why are these out of order?
 					resource.TestCheckResourceAttr(resourceName, "port_override.0.number", "3"),
@@ -280,6 +280,9 @@ func TestAccDevice_switch_portOverrides(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "port_override.2.name", "Port 2"),
 					//resource.TestCheckResourceAttr(resourceName, "port_override.2.port_profile_id", ""),
 					//resource.TestCheckResourceAttr(resourceName, "port_override.2.op_mode", "switch"),
+
+					resource.TestCheckResourceAttr(resourceName, "port_override.3.number", "4"),
+					resource.TestCheckResourceAttr(resourceName, "port_override.3.poe_mode", "pasv24"),
 				),
 			},
 			{
@@ -339,6 +342,11 @@ resource "unifi_device" "test" {
 		number              = 3
 		op_mode             = "aggregate"
 		aggregate_num_ports = 2
+	}
+
+	port_override {
+		number   = 4
+		poe_mode = "pasv24"
 	}
 }
 `, mac)


### PR DESCRIPTION
Tested with a `unifi_device` resource controlling a real switch that is powering an old UAP-AC-Lite.