### PR TITLE
Provider update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -26,9 +26,6 @@ resource "unifi_port_profile" "poe" {
   forward = "customize"
 
   native_networkconf_id = var.native_network_id
-  tagged_networkconf_ids = [
-    var.some_vlan_network_id,
-  ]
 
   poe_mode = "auto"
 }

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -69,7 +69,6 @@ resource "unifi_network" "wan" {
 - `domain_name` (String) The domain name of this network.
 - `igmp_snooping` (Boolean) Specifies whether IGMP snooping is enabled or not.
 - `internet_access_enabled` (Boolean) Specifies whether this network should be allowed to access the internet or not. Defaults to `true`.
-- `intra_network_access_enabled` (Boolean) Specifies whether this network should be allowed to access other local networks or not. Defaults to `true`.
 - `ipv6_interface_type` (String) Specifies which type of IPv6 connection to use. Must be one of either `static`, `pd`, or `none`. Defaults to `none`.
 - `ipv6_pd_interface` (String) Specifies which WAN interface to use for IPv6 PD. Must be one of either `wan` or `wan2`.
 - `ipv6_pd_prefixid` (String) Specifies the IPv6 Prefix ID.
@@ -82,6 +81,7 @@ resource "unifi_network" "wan" {
 - `ipv6_static_subnet` (String) Specifies the static IPv6 subnet when `ipv6_interface_type` is 'static'.
 - `multicast_dns` (Boolean) Specifies whether Multicast DNS (mDNS) is enabled or not on the network (Controller >=v7).
 - `network_group` (String) The group of the network. Defaults to `LAN`.
+- `network_isolation_enabled`: (Boolean) Specifies whether this network should be not allowed to access other local networks. Defaults to `false`.
 - `site` (String) The name of the site to associate the network with.
 - `subnet` (String) The subnet of the network. Must be a valid CIDR address.
 - `vlan_id` (Number) The VLAN ID of the network.

--- a/docs/resources/port_profile.md
+++ b/docs/resources/port_profile.md
@@ -46,6 +46,7 @@ resource "unifi_port_profile" "poe_disabled" {
 - `dot1x_idle_timeout` (Number) The timeout, in seconds, to use when using the MAC Based 802.1X control. Can be between 0 and 65535 Defaults to `300`.
 - `egress_rate_limit_kbps` (Number) The egress rate limit, in kpbs, for the port profile. Can be between `64` and `9999999`.
 - `egress_rate_limit_kbps_enabled` (Boolean) Enable egress rate limiting for the port profile. Defaults to `false`.
+- `excluded_networkconf_ids` (Set of String) The IDs of networks to block traffic for this port profile.
 - `forward` (String) The type forwarding to use for the port profile. Can be `all`, `native`, `customize` or `disabled`. Defaults to `native`.
 - `full_duplex` (Boolean) Enable full duplex for the port profile. Defaults to `false`.
 - `isolation` (Boolean) Enable port isolation for the port profile. Defaults to `false`.
@@ -61,6 +62,7 @@ resource "unifi_port_profile" "poe_disabled" {
 - `priority_queue2_level` (Number) The priority queue 2 level for the port profile. Can be between 0 and 100.
 - `priority_queue3_level` (Number) The priority queue 3 level for the port profile. Can be between 0 and 100.
 - `priority_queue4_level` (Number) The priority queue 4 level for the port profile. Can be between 0 and 100.
+- `show_traffic_restriction_as_allowlist` (Boolean) Show the Traffic Restriction as allow list. This only affect to the UI, the list need to be configured on `excluded_networkconf_ids` as black list.
 - `site` (String) The name of the site to associate the port profile with.
 - `speed` (Number) The link speed to set for the port profile. Can be one of `10`, `100`, `1000`, `2500`, `5000`, `10000`, `20000`, `25000`, `40000`, `50000` or `100000`
 - `stormctrl_bcast_enabled` (Boolean) Enable broadcast Storm Control for the port profile. Defaults to `false`.
@@ -74,7 +76,6 @@ resource "unifi_port_profile" "poe_disabled" {
 - `stormctrl_ucast_level` (Number) The unknown unicast Storm Control level for the port profile. Can be between 0 and 100.
 - `stormctrl_ucast_rate` (Number) The unknown unicast Storm Control rate for the port profile. Can be between 0 and 14880000.
 - `stp_port_mode` (Boolean) Enable spanning tree protocol on the port profile. Defaults to `true`.
-- `tagged_networkconf_ids` (Set of String) The IDs of networks to tag traffic with for the port profile.
 - `voice_networkconf_id` (String) The ID of network to use as the voice network on the port profile.
 
 ### Read-Only

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -75,7 +75,7 @@ resource "unifi_wlan" "wifi" {
 - `multicast_enhance` (Boolean) Indicates whether or not Multicast Enhance is turned of for the network.
 - `network_id` (String) ID of the network for this SSID
 - `no2ghz_oui` (Boolean) Connect high performance clients to 5 GHz only. Defaults to `true`.
-- `passphrase` (String, Sensitive) The passphrase for the network, this is only required if `security` is not set to `open`.
+- `passphrase` (String, Sensitive) The passphrase for the network, this is only required if `security` is not set to `open`. If you use the static string "skip", the provider will not modify the passphrase or store it in the state file.
 - `pmf_mode` (String) Enable Protected Management Frames. This cannot be disabled if using WPA 3. Valid values are `required`, `optional` and `disabled`. Defaults to `disabled`.
 - `proxy_arp` (Boolean) Reduces airtime usage by allowing APs to "proxy" common broadcast frames as unicast. Defaults to `false`.
 - `radius_profile_id` (String) ID of the RADIUS profile to use when security `wpaeap`. You can query this via the `unifi_radius_profile` data source.

--- a/examples/resources/unifi_device/resource.tf
+++ b/examples/resources/unifi_device/resource.tf
@@ -8,9 +8,6 @@ resource "unifi_port_profile" "poe" {
   forward = "customize"
 
   native_networkconf_id = var.native_network_id
-  tagged_networkconf_ids = [
-    var.some_vlan_network_id,
-  ]
 
   poe_mode = "auto"
 }

--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,15 @@ go 1.20
 // replace github.com/hashicorp/terraform-plugin-sdk/v2 => ../../hashicorp/terraform-plugin-sdk
 
 require (
+	github.com/akerl/terraform-provider-unifi v0.41.8
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/deckarep/golang-set/v2 v2.3.1
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
-	github.com/hashicorp/terraform-plugin-testing v1.3.0
-	github.com/paultyng/go-unifi v1.32.0
+	github.com/hashicorp/terraform-plugin-testing v1.4.0
+	github.com/paultyng/go-unifi v1.33.0
 	github.com/testcontainers/testcontainers-go v0.23.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.23.0
 )
@@ -324,7 +325,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.tmz.dev/musttag v0.7.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
+	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/akerl/terraform-provider-unifi v0.41.8 h1:BRPspSWwYoyJN3DYHWfms70zuKqbBIQMkL3mKsgHj0M=
+github.com/akerl/terraform-provider-unifi v0.41.8/go.mod h1:J4XzxDi6sORa52ESsk3GpLh9RaFu+cfKxokSV4Kli2M=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -548,8 +550,8 @@ github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9T
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0 h1:wcOKYwPI9IorAJEBLzgclh3xVolO7ZorYd6U1vnok14=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0/go.mod h1:qH/34G25Ugdj5FcM95cSoXzUgIbgfhVLXCcEcYaMwq8=
-github.com/hashicorp/terraform-plugin-testing v1.3.0 h1:4Pn8fSspPCRUc5zRGPNZYc00VhQmQPEH6y6Pv4e/42M=
-github.com/hashicorp/terraform-plugin-testing v1.3.0/go.mod h1:mGOfGFTVIhP9buGPZyDQhmZFIO/Ig8E0Fo694UACr64=
+github.com/hashicorp/terraform-plugin-testing v1.4.0 h1:DVIXxw7VHZvnwWVik4HzhpC2yytaJ5FpiHxz5debKmE=
+github.com/hashicorp/terraform-plugin-testing v1.4.0/go.mod h1:b7Bha24iGrbZQjT+ZE8m9crck1YjdVOZ8mfGCQ19OxA=
 github.com/hashicorp/terraform-registry-address v0.2.2 h1:lPQBg403El8PPicg/qONZJDC6YlgCVbWDtNmmZKtBno=
 github.com/hashicorp/terraform-registry-address v0.2.2/go.mod h1:LtwNbCihUoUZ3RYriyS2wF/lGPB6gF9ICLRtuDk7hSo=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
@@ -785,8 +787,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
-github.com/paultyng/go-unifi v1.32.0 h1:k3zHkL57JEmzghRgvvRuDTSkw9CtD10zdxCB9OUweYI=
-github.com/paultyng/go-unifi v1.32.0/go.mod h1:i8D+gyo5NinnDlQ5ZGdqSvRqRyHuV4zA2CLZnHb0axE=
+github.com/paultyng/go-unifi v1.33.0 h1:m4GejxTXdy5zlFu6/FDwQSe8/8VIadbgGTfnciMUQdY=
+github.com/paultyng/go-unifi v1.33.0/go.mod h1:t1CIy42PeR7IiGsFXh7hwqL/xG3JQu7e4HbhEVr74CU=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
@@ -1064,8 +1066,8 @@ go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
-go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
-go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
+go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=

--- a/internal/provider/resource_device.go
+++ b/internal/provider/resource_device.go
@@ -80,6 +80,11 @@ func resourceDevice() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 						},
+						"native_network_id": {
+							Description: "The ID of network to use as the main network on the port.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 						"port_profile_id": {
 							Description: "ID of the Port Profile used on this port.",
 							Type:        schema.TypeString,
@@ -109,6 +114,7 @@ func resourceDevice() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(2, 8),
+							Default:      0,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								if old == strconv.Itoa(0) && new == "" {
 									return true
@@ -364,6 +370,7 @@ func toPortOverride(data map[string]interface{}) (unifi.DevicePortOverrides, err
 	opMode := data["op_mode"].(string)
 	poeMode := data["poe_mode"].(string)
 	aggregateNumPorts := data["aggregate_num_ports"].(int)
+	nativeNetworkID := data["native_network_id"].(string)
 
 	return unifi.DevicePortOverrides{
 		PortIDX:           idx,
@@ -372,6 +379,7 @@ func toPortOverride(data map[string]interface{}) (unifi.DevicePortOverrides, err
 		OpMode:            opMode,
 		PoeMode:           poeMode,
 		AggregateNumPorts: aggregateNumPorts,
+		NATiveNetworkID:   nativeNetworkID,
 	}, nil
 }
 
@@ -383,6 +391,7 @@ func fromPortOverride(po unifi.DevicePortOverrides) (map[string]interface{}, err
 		"op_mode":             po.OpMode,
 		"poe_mode":            po.PoeMode,
 		"aggregate_num_ports": po.AggregateNumPorts,
+		"native_network_id":   po.NATiveNetworkID,
 	}, nil
 }
 

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -97,6 +97,12 @@ func resourceNetwork() *schema.Resource {
 				Optional:    true,
 				Default:     "LAN",
 			},
+			"network_isolation_enabled": {
+				Description: "Specifies whether this network should be not allowed to access other local networks.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
 			"dhcp_start": {
 				Description:  "The IPv4 address where the DHCP range of addresses starts.",
 				Type:         schema.TypeString,
@@ -249,12 +255,6 @@ func resourceNetwork() *schema.Resource {
 			},
 			"internet_access_enabled": {
 				Description: "Specifies whether this network should be allowed to access the internet or not.",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-			},
-			"intra_network_access_enabled": {
-				Description: "Specifies whether this network should be allowed to access other local networks or not.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
@@ -415,22 +415,23 @@ func resourceNetworkGetResourceData(d *schema.ResourceData, meta interface{}) (*
 	}
 
 	return &unifi.Network{
-		Name:              d.Get("name").(string),
-		Purpose:           d.Get("purpose").(string),
-		VLAN:              vlan,
-		IPSubnet:          cidrOneBased(d.Get("subnet").(string)),
-		NetworkGroup:      d.Get("network_group").(string),
-		DHCPDStart:        d.Get("dhcp_start").(string),
-		DHCPDStop:         d.Get("dhcp_stop").(string),
-		DHCPDEnabled:      d.Get("dhcp_enabled").(bool),
-		DHCPDLeaseTime:    d.Get("dhcp_lease").(int),
-		DHCPDBootEnabled:  d.Get("dhcpd_boot_enabled").(bool),
-		DHCPDBootServer:   d.Get("dhcpd_boot_server").(string),
-		DHCPDBootFilename: d.Get("dhcpd_boot_filename").(string),
-		DHCPRelayEnabled:  d.Get("dhcp_relay_enabled").(bool),
-		DomainName:        d.Get("domain_name").(string),
-		IGMPSnooping:      d.Get("igmp_snooping").(bool),
-		MdnsEnabled:       d.Get("multicast_dns").(bool),
+		Name:                    d.Get("name").(string),
+		Purpose:                 d.Get("purpose").(string),
+		VLAN:                    vlan,
+		IPSubnet:                cidrOneBased(d.Get("subnet").(string)),
+		NetworkGroup:            d.Get("network_group").(string),
+		NetworkIsolationEnabled: d.Get("network_isolation_enabled").(bool),
+		DHCPDStart:              d.Get("dhcp_start").(string),
+		DHCPDStop:               d.Get("dhcp_stop").(string),
+		DHCPDEnabled:            d.Get("dhcp_enabled").(bool),
+		DHCPDLeaseTime:          d.Get("dhcp_lease").(int),
+		DHCPDBootEnabled:        d.Get("dhcpd_boot_enabled").(bool),
+		DHCPDBootServer:         d.Get("dhcpd_boot_server").(string),
+		DHCPDBootFilename:       d.Get("dhcpd_boot_filename").(string),
+		DHCPRelayEnabled:        d.Get("dhcp_relay_enabled").(bool),
+		DomainName:              d.Get("domain_name").(string),
+		IGMPSnooping:            d.Get("igmp_snooping").(bool),
+		MdnsEnabled:             d.Get("multicast_dns").(bool),
 
 		DHCPDDNSEnabled: len(dhcpDNS) > 0,
 		// this is kinda hacky but ¯\_(ツ)_/¯
@@ -466,8 +467,7 @@ func resourceNetworkGetResourceData(d *schema.ResourceData, meta interface{}) (*
 		IPV6RaPriority:          d.Get("ipv6_ra_priority").(string),
 		IPV6RaValidLifetime:     d.Get("ipv6_ra_valid_lifetime").(int),
 
-		InternetAccessEnabled:     d.Get("internet_access_enabled").(bool),
-		IntraNetworkAccessEnabled: d.Get("intra_network_access_enabled").(bool),
+		InternetAccessEnabled: d.Get("internet_access_enabled").(bool),
 
 		WANIP:           d.Get("wan_ip").(string),
 		WANType:         d.Get("wan_type").(string),
@@ -567,6 +567,7 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("vlan_id", vlan)
 	d.Set("subnet", cidrZeroBased(resp.IPSubnet))
 	d.Set("network_group", resp.NetworkGroup)
+	d.Set("network_isolation_enabled", resp.NetworkIsolationEnabled)
 
 	d.Set("dhcp_dns", dhcpDNS)
 	d.Set("dhcp_enabled", resp.DHCPDEnabled)
@@ -586,7 +587,6 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("domain_name", resp.DomainName)
 	d.Set("igmp_snooping", resp.IGMPSnooping)
 	d.Set("internet_access_enabled", resp.InternetAccessEnabled)
-	d.Set("intra_network_access_enabled", resp.IntraNetworkAccessEnabled)
 	d.Set("ipv6_interface_type", resp.IPV6InterfaceType)
 	d.Set("ipv6_pd_interface", resp.IPV6PDInterface)
 	d.Set("ipv6_pd_prefixid", resp.IPV6PDPrefixid)

--- a/internal/provider/resource_wlan.go
+++ b/internal/provider/resource_wlan.go
@@ -249,6 +249,9 @@ func resourceWLANGetResourceData(d *schema.ResourceData, meta interface{}) (*uni
 	case "open":
 		passphrase = ""
 	}
+	if passphrase == "skip" {
+		passphrase = ""
+	}
 
 	pmf := d.Get("pmf_mode").(string)
 	wpa3 := d.Get("wpa3_support").(bool)
@@ -385,6 +388,11 @@ func resourceWLANSetResourceData(resp *unifi.WLAN, d *schema.ResourceData, meta 
 	case "wpapsk":
 		wpa3 = resp.WPA3Support
 		wpa3Transition = resp.WPA3Transition
+	}
+
+	inputPassphrase := d.Get("passphrase").(string)
+	if inputPassphrase == "skip" {
+		passphrase = "skip"
 	}
 
 	macFilterEnabled := resp.MACFilterEnabled

--- a/vendor/github.com/hashicorp/terraform-plugin-testing/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-testing/helper/resource/testing.go
@@ -162,7 +162,7 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 		log.Printf("Sweeper Tests for region (%s) ran successfully:\n", region)
 		for sweeper, sweeperErr := range regionSweeperRunList {
 			if sweeperErr == nil {
-				fmt.Printf("\t- %s\n", sweeper)
+				log.Printf("\t- %s\n", sweeper)
 			} else {
 				regionSweeperErrorFound = true
 			}
@@ -173,7 +173,7 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 			log.Printf("Sweeper Tests for region (%s) ran unsuccessfully:\n", region)
 			for sweeper, sweeperErr := range regionSweeperRunList {
 				if sweeperErr != nil {
-					fmt.Printf("\t- %s: %s\n", sweeper, sweeperErr)
+					log.Printf("\t- %s: %s\n", sweeper, sweeperErr)
 				}
 			}
 		}

--- a/vendor/github.com/hashicorp/terraform-plugin-testing/plancheck/expect_sensitive_value.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-testing/plancheck/expect_sensitive_value.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package plancheck
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var _ PlanCheck = expectSensitiveValue{}
+
+type expectSensitiveValue struct {
+	resourceAddress string
+	attributePath   tfjsonpath.Path
+}
+
+// CheckPlan implements the plan check logic.
+func (e expectSensitiveValue) CheckPlan(ctx context.Context, req CheckPlanRequest, resp *CheckPlanResponse) {
+
+	for _, rc := range req.Plan.ResourceChanges {
+		if e.resourceAddress != rc.Address {
+			continue
+		}
+
+		result, err := tfjsonpath.Traverse(rc.Change.AfterSensitive, e.attributePath)
+		if err != nil {
+			resp.Error = err
+			return
+		}
+
+		isSensitive, ok := result.(bool)
+		if !ok {
+			resp.Error = fmt.Errorf("invalid path: the path value cannot be asserted as bool")
+			return
+		}
+
+		if !isSensitive {
+			resp.Error = fmt.Errorf("attribute at path is not sensitive")
+			return
+		}
+
+		return
+	}
+
+	resp.Error = fmt.Errorf("%s - Resource not found in plan ResourceChanges", e.resourceAddress)
+}
+
+// ExpectSensitiveValue returns a plan check that asserts that the specified attribute at the given resource has a sensitive value.
+//
+// Due to implementation differences between the terraform-plugin-sdk and the terraform-plugin-framework, representation of sensitive
+// values may differ. For example, terraform-plugin-sdk based providers may have less precise representations of sensitive values, such
+// as marking whole maps as sensitive rather than individual element values.
+func ExpectSensitiveValue(resourceAddress string, attributePath tfjsonpath.Path) PlanCheck {
+	return expectSensitiveValue{
+		resourceAddress: resourceAddress,
+		attributePath:   attributePath,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-testing/plancheck/expect_unknown_value.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-testing/plancheck/expect_unknown_value.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package plancheck
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var _ PlanCheck = expectUnknownValue{}
+
+type expectUnknownValue struct {
+	resourceAddress string
+	attributePath   tfjsonpath.Path
+}
+
+// CheckPlan implements the plan check logic.
+func (e expectUnknownValue) CheckPlan(ctx context.Context, req CheckPlanRequest, resp *CheckPlanResponse) {
+
+	for _, rc := range req.Plan.ResourceChanges {
+		if e.resourceAddress != rc.Address {
+			continue
+		}
+
+		result, err := tfjsonpath.Traverse(rc.Change.AfterUnknown, e.attributePath)
+		if err != nil {
+			resp.Error = err
+			return
+		}
+
+		isUnknown, ok := result.(bool)
+		if !ok {
+			resp.Error = fmt.Errorf("invalid path: the path value cannot be asserted as bool")
+			return
+		}
+
+		if !isUnknown {
+			resp.Error = fmt.Errorf("attribute at path is known")
+			return
+		}
+
+		return
+	}
+
+	resp.Error = fmt.Errorf("%s - Resource not found in plan ResourceChanges", e.resourceAddress)
+}
+
+// ExpectUnknownValue returns a plan check that asserts that the specified attribute at the given resource has an unknown value.
+//
+// Due to implementation differences between the terraform-plugin-sdk and the terraform-plugin-framework, representation of unknown
+// values may differ. For example, terraform-plugin-sdk based providers may have less precise representations of unknown values, such
+// as marking whole maps as unknown rather than individual element values.
+func ExpectUnknownValue(resourceAddress string, attributePath tfjsonpath.Path) PlanCheck {
+	return expectUnknownValue{
+		resourceAddress: resourceAddress,
+		attributePath:   attributePath,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-testing/tfjsonpath/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-testing/tfjsonpath/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package tfjsonpath implements terraform-json path functionality, which defines
+// traversals into Terraform JSON data, for testing purposes.
+package tfjsonpath

--- a/vendor/github.com/hashicorp/terraform-plugin-testing/tfjsonpath/path.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-testing/tfjsonpath/path.go
@@ -1,0 +1,107 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfjsonpath
+
+import (
+	"fmt"
+)
+
+// Path represents exact traversal steps specifying a value inside
+// Terraform JSON data. These steps always start from a MapStep with a key
+// specifying the name of a top-level JSON object or array.
+//
+// The [terraform-json] library serves as the de facto documentation
+// for JSON format of Terraform data.
+//
+// Use the New() function to create a Path with an initial AtMapKey() step.
+// Path functionality follows a builder pattern, which allows for chaining method
+// calls to construct a full path. The available traversal steps after Path
+// creation are:
+//
+//   - AtSliceIndex(): Step into a slice at a specific 0-based index
+//   - AtMapKey(): Step into a map at a specific key
+//
+// For example, to represent the first element of a JSON array
+// underneath a "some_array" property of this JSON value:
+//
+//	   {
+//	     "some_array": [true]
+//	   }
+//
+//	 The path code would be represented by:
+//
+//		tfjsonpath.New("some_array").AtSliceIndex(0)
+//
+// [terraform-json]: (https://pkg.go.dev/github.com/hashicorp/terraform-json)
+type Path struct {
+	steps []step
+}
+
+// New creates a new path with an initial MapStep.
+func New(name string) Path {
+	return Path{
+		steps: []step{
+			MapStep(name),
+		},
+	}
+}
+
+// AtSliceIndex returns a copied Path with a new SliceStep at the end.
+func (s Path) AtSliceIndex(index int) Path {
+	newSteps := append(s.steps, SliceStep(index))
+	s.steps = newSteps
+	return s
+}
+
+// AtMapKey returns a copied Path with a new MapStep at the end.
+func (s Path) AtMapKey(key string) Path {
+	newSteps := append(s.steps, MapStep(key))
+	s.steps = newSteps
+	return s
+}
+
+// Traverse returns the element found when traversing the given
+// object using the specified Path. The object is an unmarshalled
+// JSON object representing Terraform data.
+//
+// Traverse returns an error if the value specified by the Path
+// is not found in the given object or if the given object does not
+// conform to format of Terraform JSON data.
+func Traverse(object any, attrPath Path) (any, error) {
+	_, ok := object.(map[string]any)
+
+	if !ok {
+		return nil, fmt.Errorf("cannot convert given object to map[string]any")
+	}
+
+	result := object
+
+	for _, step := range attrPath.steps {
+		switch s := step.(type) {
+		case MapStep:
+			mapObj, ok := result.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("path not found: cannot convert object at MapStep %s to map[string]any", string(s))
+			}
+			result, ok = mapObj[string(s)]
+			if !ok {
+				return nil, fmt.Errorf("path not found: specified key %s not found in map", string(s))
+			}
+
+		case SliceStep:
+			sliceObj, ok := result.([]any)
+			if !ok {
+				return nil, fmt.Errorf("path not found: cannot convert object at SliceStep %d to []any", s)
+			}
+
+			if int(s) >= len(sliceObj) {
+				return nil, fmt.Errorf("path not found: SliceStep index %d is out of range with slice length %d", s, len(sliceObj))
+			}
+
+			result = sliceObj[s]
+		}
+	}
+
+	return result, nil
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-testing/tfjsonpath/step.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-testing/tfjsonpath/step.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfjsonpath
+
+// step represents a traversal type indicating the underlying Go type
+// representation for a Terraform JSON value.
+type step interface{}
+
+// MapStep represents a traversal for map[string]any
+type MapStep string
+
+// SliceStep represents a traversal for []any
+type SliceStep int

--- a/vendor/github.com/paultyng/go-unifi/unifi/device.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/device.generated.go
@@ -51,8 +51,7 @@ type Device struct {
 	LcmIDleTimeout              int                               `json:"lcm_idle_timeout,omitempty"` // [1-9][0-9]|[1-9][0-9][0-9]|[1-2][0-9][0-9][0-9]|3[0-5][0-9][0-9]|3600
 	LcmIDleTimeoutOverride      bool                              `json:"lcm_idle_timeout_override,omitempty"`
 	LcmNightModeBegins          string                            `json:"lcm_night_mode_begins,omitempty"` // (^$)|(^(0[1-9])|(1[0-9])|(2[0-3])):([0-5][0-9]$)
-	LcmNightModeEnabled         bool                              `json:"lcm_night_mode_enabled,omitempty"`
-	LcmNightModeEnds            string                            `json:"lcm_night_mode_ends,omitempty"` // (^$)|(^(0[1-9])|(1[0-9])|(2[0-3])):([0-5][0-9]$)
+	LcmNightModeEnds            string                            `json:"lcm_night_mode_ends,omitempty"`   // (^$)|(^(0[1-9])|(1[0-9])|(2[0-3])):([0-5][0-9]$)
 	LcmSettingsRestrictedAccess bool                              `json:"lcm_settings_restricted_access,omitempty"`
 	LcmTrackerEnabled           bool                              `json:"lcm_tracker_enabled,omitempty"`
 	LcmTrackerSeed              string                            `json:"lcm_tracker_seed,omitempty"`              // .{0,50}
@@ -238,40 +237,46 @@ func (dst *DeviceOutletOverrides) UnmarshalJSON(b []byte) error {
 }
 
 type DevicePortOverrides struct {
-	AggregateNumPorts            int      `json:"aggregate_num_ports,omitempty"` // [2-8]
-	Autoneg                      bool     `json:"autoneg,omitempty"`
-	Dot1XCtrl                    string   `json:"dot1x_ctrl,omitempty"`             // auto|force_authorized|force_unauthorized|mac_based|multi_host
-	Dot1XIDleTimeout             int      `json:"dot1x_idle_timeout,omitempty"`     // [0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]
-	EgressRateLimitKbps          int      `json:"egress_rate_limit_kbps,omitempty"` // 6[4-9]|[7-9][0-9]|[1-9][0-9]{2,6}
-	EgressRateLimitKbpsEnabled   bool     `json:"egress_rate_limit_kbps_enabled,omitempty"`
-	FullDuplex                   bool     `json:"full_duplex,omitempty"`
-	Isolation                    bool     `json:"isolation,omitempty"`
-	LldpmedEnabled               bool     `json:"lldpmed_enabled,omitempty"`
-	LldpmedNotifyEnabled         bool     `json:"lldpmed_notify_enabled,omitempty"`
-	MirrorPortIDX                int      `json:"mirror_port_idx,omitempty"` // [1-9]|[1-4][0-9]|5[0-2]
-	Name                         string   `json:"name,omitempty"`            // .{0,128}
-	OpMode                       string   `json:"op_mode,omitempty"`         // switch|mirror|aggregate
-	PoeMode                      string   `json:"poe_mode,omitempty"`        // auto|pasv24|passthrough|off
-	PortIDX                      int      `json:"port_idx,omitempty"`        // [1-9]|[1-4][0-9]|5[0-2]
-	PortProfileID                string   `json:"portconf_id,omitempty"`     // [\d\w]+
-	PortSecurityEnabled          bool     `json:"port_security_enabled,omitempty"`
-	PortSecurityMACAddress       []string `json:"port_security_mac_address,omitempty"` // ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-	PriorityQueue1Level          int      `json:"priority_queue1_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	PriorityQueue2Level          int      `json:"priority_queue2_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	PriorityQueue3Level          int      `json:"priority_queue3_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	PriorityQueue4Level          int      `json:"priority_queue4_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	Speed                        int      `json:"speed,omitempty"`                     // 10|100|1000|2500|5000|10000|20000|25000|40000|50000|100000
-	StormctrlBroadcastastEnabled bool     `json:"stormctrl_bcast_enabled,omitempty"`
-	StormctrlBroadcastastLevel   int      `json:"stormctrl_bcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlBroadcastastRate    int      `json:"stormctrl_bcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StormctrlMcastEnabled        bool     `json:"stormctrl_mcast_enabled,omitempty"`
-	StormctrlMcastLevel          int      `json:"stormctrl_mcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlMcastRate           int      `json:"stormctrl_mcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StormctrlType                string   `json:"stormctrl_type,omitempty"`        // level|rate
-	StormctrlUcastEnabled        bool     `json:"stormctrl_ucast_enabled,omitempty"`
-	StormctrlUcastLevel          int      `json:"stormctrl_ucast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlUcastRate           int      `json:"stormctrl_ucast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StpPortMode                  bool     `json:"stp_port_mode,omitempty"`
+	AggregateNumPorts                 int      `json:"aggregate_num_ports,omitempty"` // [2-8]
+	Autoneg                           bool     `json:"autoneg,omitempty"`
+	Dot1XCtrl                         string   `json:"dot1x_ctrl,omitempty"`             // auto|force_authorized|force_unauthorized|mac_based|multi_host
+	Dot1XIDleTimeout                  int      `json:"dot1x_idle_timeout,omitempty"`     // [0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]
+	EgressRateLimitKbps               int      `json:"egress_rate_limit_kbps,omitempty"` // 6[4-9]|[7-9][0-9]|[1-9][0-9]{2,6}
+	EgressRateLimitKbpsEnabled        bool     `json:"egress_rate_limit_kbps_enabled,omitempty"`
+	ExcludedNetworkIDs                []string `json:"excluded_networkconf_ids,omitempty"`
+	Forward                           string   `json:"forward,omitempty"` // all|native|customize|disabled
+	FullDuplex                        bool     `json:"full_duplex,omitempty"`
+	Isolation                         bool     `json:"isolation,omitempty"`
+	LldpmedEnabled                    bool     `json:"lldpmed_enabled,omitempty"`
+	LldpmedNotifyEnabled              bool     `json:"lldpmed_notify_enabled,omitempty"`
+	MirrorPortIDX                     int      `json:"mirror_port_idx,omitempty"` // [1-9]|[1-4][0-9]|5[0-2]
+	NATiveNetworkID                   string   `json:"native_networkconf_id,omitempty"`
+	Name                              string   `json:"name,omitempty"`        // .{0,128}
+	OpMode                            string   `json:"op_mode,omitempty"`     // switch|mirror|aggregate
+	PoeMode                           string   `json:"poe_mode,omitempty"`    // auto|pasv24|passthrough|off
+	PortIDX                           int      `json:"port_idx,omitempty"`    // [1-9]|[1-4][0-9]|5[0-2]
+	PortProfileID                     string   `json:"portconf_id,omitempty"` // [\d\w]+
+	PortSecurityEnabled               bool     `json:"port_security_enabled,omitempty"`
+	PortSecurityMACAddress            []string `json:"port_security_mac_address,omitempty"` // ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
+	PriorityQueue1Level               int      `json:"priority_queue1_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	PriorityQueue2Level               int      `json:"priority_queue2_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	PriorityQueue3Level               int      `json:"priority_queue3_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	PriorityQueue4Level               int      `json:"priority_queue4_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	SettingPreference                 string   `json:"setting_preference,omitempty"`        // auto|manual
+	ShowTrafficRestrictionAsAllowlist bool     `json:"show_traffic_restriction_as_allowlist,omitempty"`
+	Speed                             int      `json:"speed,omitempty"` // 10|100|1000|2500|5000|10000|20000|25000|40000|50000|100000
+	StormctrlBroadcastastEnabled      bool     `json:"stormctrl_bcast_enabled,omitempty"`
+	StormctrlBroadcastastLevel        int      `json:"stormctrl_bcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlBroadcastastRate         int      `json:"stormctrl_bcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StormctrlMcastEnabled             bool     `json:"stormctrl_mcast_enabled,omitempty"`
+	StormctrlMcastLevel               int      `json:"stormctrl_mcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlMcastRate                int      `json:"stormctrl_mcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StormctrlType                     string   `json:"stormctrl_type,omitempty"`        // level|rate
+	StormctrlUcastEnabled             bool     `json:"stormctrl_ucast_enabled,omitempty"`
+	StormctrlUcastLevel               int      `json:"stormctrl_ucast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlUcastRate                int      `json:"stormctrl_ucast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StpPortMode                       bool     `json:"stp_port_mode,omitempty"`
+	VoiceNetworkID                    string   `json:"voice_networkconf_id,omitempty"`
 }
 
 func (dst *DevicePortOverrides) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/paultyng/go-unifi/unifi/network.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/network.generated.go
@@ -26,7 +26,6 @@ type Network struct {
 	NoEdit   bool   `json:"attr_no_edit,omitempty"`
 
 	AutoScaleEnabled             bool                            `json:"auto_scale_enabled"`
-	ClientMACList                []string                        `json:"client_mac_list,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
 	DHCPDBootEnabled             bool                            `json:"dhcpd_boot_enabled"`
 	DHCPDBootFilename            string                          `json:"dhcpd_boot_filename,omitempty"` // .{1,256}
 	DHCPDBootServer              string                          `json:"dhcpd_boot_server"`             // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$|(?=^.{3,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)|[a-zA-Z0-9-]{1,63}|^$
@@ -80,13 +79,15 @@ type Network struct {
 	IGMPGroupmembership          int                             `json:"igmp_groupmembership,omitempty"` // [2-9]|[1-9][0-9]{1,2}|[1-2][0-9]{3}|3[0-5][0-9]{2}|3600|^$
 	IGMPMaxresponse              int                             `json:"igmp_maxresponse,omitempty"`     // [1-9]|1[0-9]|2[0-5]|^$
 	IGMPMcrtrexpiretime          int                             `json:"igmp_mcrtrexpiretime,omitempty"` // [0-9]|[1-9][0-9]{1,2}|[1-2][0-9]{3}|3[0-5][0-9]{2}|3600|^$
-	IGMPQuerier                  string                          `json:"igmp_querier"`                   // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
+	IGMPProxyDownstream          bool                            `json:"igmp_proxy_downstream"`
+	IGMPProxyUpstream            bool                            `json:"igmp_proxy_upstream"`
+	IGMPQuerier                  string                          `json:"igmp_querier"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
 	IGMPSnooping                 bool                            `json:"igmp_snooping"`
 	IGMPSupression               bool                            `json:"igmp_supression"`
 	IPSecDhGroup                 int                             `json:"ipsec_dh_group,omitempty"` // 2|5|14|15|16|19|20|21|25|26
 	IPSecDynamicRouting          bool                            `json:"ipsec_dynamic_routing"`
 	IPSecEncryption              string                          `json:"ipsec_encryption,omitempty"`   // aes128|aes192|aes256|3des
-	IPSecEspDhGroup              int                             `json:"ipsec_esp_dh_group,omitempty"` // 1|2|5|14|15|16|17|18
+	IPSecEspDhGroup              int                             `json:"ipsec_esp_dh_group,omitempty"` // 1|2|5|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32
 	IPSecHash                    string                          `json:"ipsec_hash,omitempty"`         // sha1|md5|sha256|sha384|sha512
 	IPSecIkeDhGroup              int                             `json:"ipsec_ike_dh_group,omitempty"` // 1|2|5|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32
 	IPSecInterface               string                          `json:"ipsec_interface,omitempty"`    // wan|wan2
@@ -107,8 +108,6 @@ type Network struct {
 	IPV6RaValidLifetime          int                             `json:"ipv6_ra_valid_lifetime,omitempty"`     // ^([0-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-8][0-9]{4}|9[0-8][0-9]{3}|99[0-8][0-9]{2}|999[0-8][0-9]|9999[0-9]|[1-8][0-9]{5}|9[0-8][0-9]{4}|99[0-8][0-9]{3}|999[0-8][0-9]{2}|9999[0-8][0-9]|99999[0-9]|[1-8][0-9]{6}|9[0-8][0-9]{5}|99[0-8][0-9]{4}|999[0-8][0-9]{3}|9999[0-8][0-9]{2}|99999[0-8][0-9]|999999[0-9]|[12][0-9]{7}|30[0-9]{6}|31[0-4][0-9]{5}|315[0-2][0-9]{4}|3153[0-5][0-9]{3}|31536000)$|^$
 	IPV6Subnet                   string                          `json:"ipv6_subnet,omitempty"`
 	InternetAccessEnabled        bool                            `json:"internet_access_enabled"`
-	IntraNetworkAccessEnabled    bool                            `json:"intra_network_access_enabled"`
-	IntraNetworks                []string                        `json:"intra_networks,omitempty"` // [\d\w]+
 	IsNAT                        bool                            `json:"is_nat"`
 	L2TpAllowWeakCiphers         bool                            `json:"l2tp_allow_weak_ciphers"`
 	L2TpInterface                string                          `json:"l2tp_interface,omitempty"`    // wan|wan2
@@ -121,10 +120,13 @@ type Network struct {
 	NATOutboundIPAddresses       []NetworkNATOutboundIPAddresses `json:"nat_outbound_ip_addresses,omitempty"`
 	Name                         string                          `json:"name,omitempty"`         // .{1,128}
 	NetworkGroup                 string                          `json:"networkgroup,omitempty"` // LAN[2-8]?
+	NetworkIsolationEnabled      bool                            `json:"network_isolation_enabled"`
 	OpenVPNConfiguration         string                          `json:"openvpn_configuration,omitempty"`
 	OpenVPNConfigurationFilename string                          `json:"openvpn_configuration_filename,omitempty"`
+	OpenVPNInterface             string                          `json:"openvpn_interface,omitempty"`      // wan|wan2
 	OpenVPNLocalAddress          string                          `json:"openvpn_local_address,omitempty"`  // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
 	OpenVPNLocalPort             int                             `json:"openvpn_local_port,omitempty"`     // ^([1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-4][0-9]{2}|[6][5][5][0-2][0-9]|[6][5][5][3][0-5])$
+	OpenVPNLocalWANIP            string                          `json:"openvpn_local_wan_ip,omitempty"`   // ^any$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
 	OpenVPNMode                  string                          `json:"openvpn_mode,omitempty"`           // site-to-site|client|server
 	OpenVPNRemoteAddress         string                          `json:"openvpn_remote_address,omitempty"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
 	OpenVPNRemoteHost            string                          `json:"openvpn_remote_host,omitempty"`    // [^\"\' ]+|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
@@ -150,10 +152,12 @@ type Network struct {
 	VLANEnabled                  bool                            `json:"vlan_enabled"`
 	VPNClientDefaultRoute        bool                            `json:"vpn_client_default_route"`
 	VPNClientPullDNS             bool                            `json:"vpn_client_pull_dns"`
-	VPNType                      string                          `json:"vpn_type,omitempty"`           // auto|ipsec-vpn|openvpn-client|openvpn-vpn|pptp-client|l2tp-server|pptp-server|uid-server|wireguard-server
+	VPNProtocol                  string                          `json:"vpn_protocol,omitempty"`       // tcp|udp
+	VPNType                      string                          `json:"vpn_type,omitempty"`           // auto|ipsec-vpn|openvpn-client|openvpn-server|openvpn-vpn|pptp-client|l2tp-server|pptp-server|uid-server|wireguard-server
 	VrrpIPSubnetGw1              string                          `json:"vrrp_ip_subnet_gw1,omitempty"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/([1-9]|[1-2][0-9]|30)$
 	VrrpIPSubnetGw2              string                          `json:"vrrp_ip_subnet_gw2,omitempty"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/([1-9]|[1-2][0-9]|30)$
 	VrrpVrid                     int                             `json:"vrrp_vrid,omitempty"`          // [1-9]|[1-9][0-9]
+	WANDHCPCos                   int                             `json:"wan_dhcp_cos,omitempty"`       // [0-7]|^$
 	WANDHCPOptions               []NetworkWANDHCPOptions         `json:"wan_dhcp_options,omitempty"`
 	WANDHCPv6PDSize              int                             `json:"wan_dhcpv6_pd_size,omitempty"`      // ^(4[89]|5[0-9]|6[0-4])$|^$
 	WANDNS1                      string                          `json:"wan_dns1"`                          // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
@@ -184,45 +188,53 @@ type Network struct {
 	WireguardInterface           string                          `json:"wireguard_interface,omitempty"`    // wan|wan2
 	WireguardLocalWANIP          string                          `json:"wireguard_local_wan_ip,omitempty"` // ^any$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
 	WireguardPublicKey           string                          `json:"wireguard_public_key,omitempty"`
+	XAuthKey                     string                          `json:"x_auth_key,omitempty"`
+	XCaCrt                       string                          `json:"x_ca_crt,omitempty"`
+	XCaKey                       string                          `json:"x_ca_key,omitempty"`
+	XDhKey                       string                          `json:"x_dh_key,omitempty"`
 	XIPSecPreSharedKey           string                          `json:"x_ipsec_pre_shared_key,omitempty"` // [^\"\' ]+
 	XOpenVPNPassword             string                          `json:"x_openvpn_password,omitempty"`
 	XOpenVPNSharedSecretKey      string                          `json:"x_openvpn_shared_secret_key,omitempty"` // [0-9A-Fa-f]{512}
 	XPptpcPassword               string                          `json:"x_pptpc_password,omitempty"`            // [^\"\' ]+
-	XWANPassword                 string                          `json:"x_wan_password,omitempty"`              // [^"' ]+
+	XServerCrt                   string                          `json:"x_server_crt,omitempty"`
+	XServerKey                   string                          `json:"x_server_key,omitempty"`
+	XSharedClientCrt             string                          `json:"x_shared_client_crt,omitempty"`
+	XSharedClientKey             string                          `json:"x_shared_client_key,omitempty"`
+	XWANPassword                 string                          `json:"x_wan_password,omitempty"` // [^"' ]+
 	XWireguardPrivateKey         string                          `json:"x_wireguard_private_key,omitempty"`
 }
 
 func (dst *Network) UnmarshalJSON(b []byte) error {
 	type Alias Network
 	aux := &struct {
-		DHCPDLeaseTime            emptyStringInt `json:"dhcpd_leasetime"`
-		DHCPDTimeOffset           emptyStringInt `json:"dhcpd_time_offset"`
-		DHCPDV6LeaseTime          emptyStringInt `json:"dhcpdv6_leasetime"`
-		IGMPGroupmembership       emptyStringInt `json:"igmp_groupmembership"`
-		IGMPMaxresponse           emptyStringInt `json:"igmp_maxresponse"`
-		IGMPMcrtrexpiretime       emptyStringInt `json:"igmp_mcrtrexpiretime"`
-		IPSecDhGroup              emptyStringInt `json:"ipsec_dh_group"`
-		IPSecEspDhGroup           emptyStringInt `json:"ipsec_esp_dh_group"`
-		IPSecIkeDhGroup           emptyStringInt `json:"ipsec_ike_dh_group"`
-		IPV6RaPreferredLifetime   emptyStringInt `json:"ipv6_ra_preferred_lifetime"`
-		IPV6RaValidLifetime       emptyStringInt `json:"ipv6_ra_valid_lifetime"`
-		InternetAccessEnabled     *bool          `json:"internet_access_enabled"`
-		IntraNetworkAccessEnabled *bool          `json:"intra_network_access_enabled"`
-		LocalPort                 emptyStringInt `json:"local_port"`
-		OpenVPNLocalPort          emptyStringInt `json:"openvpn_local_port"`
-		OpenVPNRemotePort         emptyStringInt `json:"openvpn_remote_port"`
-		PptpcRouteDistance        emptyStringInt `json:"pptpc_route_distance"`
-		Priority                  emptyStringInt `json:"priority"`
-		RouteDistance             emptyStringInt `json:"route_distance"`
-		VLAN                      emptyStringInt `json:"vlan"`
-		VrrpVrid                  emptyStringInt `json:"vrrp_vrid"`
-		WANDHCPv6PDSize           emptyStringInt `json:"wan_dhcpv6_pd_size"`
-		WANEgressQOS              emptyStringInt `json:"wan_egress_qos"`
-		WANLoadBalanceWeight      emptyStringInt `json:"wan_load_balance_weight"`
-		WANPrefixlen              emptyStringInt `json:"wan_prefixlen"`
-		WANSmartqDownRate         emptyStringInt `json:"wan_smartq_down_rate"`
-		WANSmartqUpRate           emptyStringInt `json:"wan_smartq_up_rate"`
-		WANVLAN                   emptyStringInt `json:"wan_vlan"`
+		DHCPDLeaseTime          emptyStringInt `json:"dhcpd_leasetime"`
+		DHCPDTimeOffset         emptyStringInt `json:"dhcpd_time_offset"`
+		DHCPDV6LeaseTime        emptyStringInt `json:"dhcpdv6_leasetime"`
+		IGMPGroupmembership     emptyStringInt `json:"igmp_groupmembership"`
+		IGMPMaxresponse         emptyStringInt `json:"igmp_maxresponse"`
+		IGMPMcrtrexpiretime     emptyStringInt `json:"igmp_mcrtrexpiretime"`
+		IPSecDhGroup            emptyStringInt `json:"ipsec_dh_group"`
+		IPSecEspDhGroup         emptyStringInt `json:"ipsec_esp_dh_group"`
+		IPSecIkeDhGroup         emptyStringInt `json:"ipsec_ike_dh_group"`
+		IPV6RaPreferredLifetime emptyStringInt `json:"ipv6_ra_preferred_lifetime"`
+		IPV6RaValidLifetime     emptyStringInt `json:"ipv6_ra_valid_lifetime"`
+		InternetAccessEnabled   *bool          `json:"internet_access_enabled"`
+		LocalPort               emptyStringInt `json:"local_port"`
+		OpenVPNLocalPort        emptyStringInt `json:"openvpn_local_port"`
+		OpenVPNRemotePort       emptyStringInt `json:"openvpn_remote_port"`
+		PptpcRouteDistance      emptyStringInt `json:"pptpc_route_distance"`
+		Priority                emptyStringInt `json:"priority"`
+		RouteDistance           emptyStringInt `json:"route_distance"`
+		VLAN                    emptyStringInt `json:"vlan"`
+		VrrpVrid                emptyStringInt `json:"vrrp_vrid"`
+		WANDHCPCos              emptyStringInt `json:"wan_dhcp_cos"`
+		WANDHCPv6PDSize         emptyStringInt `json:"wan_dhcpv6_pd_size"`
+		WANEgressQOS            emptyStringInt `json:"wan_egress_qos"`
+		WANLoadBalanceWeight    emptyStringInt `json:"wan_load_balance_weight"`
+		WANPrefixlen            emptyStringInt `json:"wan_prefixlen"`
+		WANSmartqDownRate       emptyStringInt `json:"wan_smartq_down_rate"`
+		WANSmartqUpRate         emptyStringInt `json:"wan_smartq_up_rate"`
+		WANVLAN                 emptyStringInt `json:"wan_vlan"`
 
 		*Alias
 	}{
@@ -245,7 +257,6 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 	dst.IPV6RaPreferredLifetime = int(aux.IPV6RaPreferredLifetime)
 	dst.IPV6RaValidLifetime = int(aux.IPV6RaValidLifetime)
 	dst.InternetAccessEnabled = emptyBoolToTrue(aux.InternetAccessEnabled)
-	dst.IntraNetworkAccessEnabled = emptyBoolToTrue(aux.IntraNetworkAccessEnabled)
 	dst.LocalPort = int(aux.LocalPort)
 	dst.OpenVPNLocalPort = int(aux.OpenVPNLocalPort)
 	dst.OpenVPNRemotePort = int(aux.OpenVPNRemotePort)
@@ -254,6 +265,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 	dst.RouteDistance = int(aux.RouteDistance)
 	dst.VLAN = int(aux.VLAN)
 	dst.VrrpVrid = int(aux.VrrpVrid)
+	dst.WANDHCPCos = int(aux.WANDHCPCos)
 	dst.WANDHCPv6PDSize = int(aux.WANDHCPv6PDSize)
 	dst.WANEgressQOS = int(aux.WANEgressQOS)
 	dst.WANLoadBalanceWeight = int(aux.WANLoadBalanceWeight)

--- a/vendor/github.com/paultyng/go-unifi/unifi/port_profile.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/port_profile.generated.go
@@ -25,41 +25,42 @@ type PortProfile struct {
 	NoDelete bool   `json:"attr_no_delete,omitempty"`
 	NoEdit   bool   `json:"attr_no_edit,omitempty"`
 
-	Autoneg                      bool     `json:"autoneg"`
-	Dot1XCtrl                    string   `json:"dot1x_ctrl,omitempty"`             // auto|force_authorized|force_unauthorized|mac_based|multi_host
-	Dot1XIDleTimeout             int      `json:"dot1x_idle_timeout,omitempty"`     // [0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]
-	EgressRateLimitKbps          int      `json:"egress_rate_limit_kbps,omitempty"` // 6[4-9]|[7-9][0-9]|[1-9][0-9]{2,6}
-	EgressRateLimitKbpsEnabled   bool     `json:"egress_rate_limit_kbps_enabled"`
-	Forward                      string   `json:"forward,omitempty"` // all|native|customize|disabled
-	FullDuplex                   bool     `json:"full_duplex"`
-	Isolation                    bool     `json:"isolation"`
-	LldpmedEnabled               bool     `json:"lldpmed_enabled"`
-	LldpmedNotifyEnabled         bool     `json:"lldpmed_notify_enabled"`
-	NATiveNetworkID              string   `json:"native_networkconf_id"`
-	Name                         string   `json:"name,omitempty"`
-	OpMode                       string   `json:"op_mode,omitempty"`  // switch
-	PoeMode                      string   `json:"poe_mode,omitempty"` // auto|pasv24|passthrough|off
-	PortSecurityEnabled          bool     `json:"port_security_enabled"`
-	PortSecurityMACAddress       []string `json:"port_security_mac_address,omitempty"` // ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-	PriorityQueue1Level          int      `json:"priority_queue1_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	PriorityQueue2Level          int      `json:"priority_queue2_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	PriorityQueue3Level          int      `json:"priority_queue3_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	PriorityQueue4Level          int      `json:"priority_queue4_level,omitempty"`     // [0-9]|[1-9][0-9]|100
-	SettingPreference            string   `json:"setting_preference,omitempty"`        // auto|manual
-	Speed                        int      `json:"speed,omitempty"`                     // 10|100|1000|2500|5000|10000|20000|25000|40000|50000|100000
-	StormctrlBroadcastastEnabled bool     `json:"stormctrl_bcast_enabled"`
-	StormctrlBroadcastastLevel   int      `json:"stormctrl_bcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlBroadcastastRate    int      `json:"stormctrl_bcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StormctrlMcastEnabled        bool     `json:"stormctrl_mcast_enabled"`
-	StormctrlMcastLevel          int      `json:"stormctrl_mcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlMcastRate           int      `json:"stormctrl_mcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StormctrlType                string   `json:"stormctrl_type,omitempty"`        // level|rate
-	StormctrlUcastEnabled        bool     `json:"stormctrl_ucast_enabled"`
-	StormctrlUcastLevel          int      `json:"stormctrl_ucast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlUcastRate           int      `json:"stormctrl_ucast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StpPortMode                  bool     `json:"stp_port_mode"`
-	TaggedNetworkIDs             []string `json:"tagged_networkconf_ids,omitempty"`
-	VoiceNetworkID               string   `json:"voice_networkconf_id"`
+	Autoneg                           bool     `json:"autoneg"`
+	Dot1XCtrl                         string   `json:"dot1x_ctrl,omitempty"`             // auto|force_authorized|force_unauthorized|mac_based|multi_host
+	Dot1XIDleTimeout                  int      `json:"dot1x_idle_timeout,omitempty"`     // [0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]
+	EgressRateLimitKbps               int      `json:"egress_rate_limit_kbps,omitempty"` // 6[4-9]|[7-9][0-9]|[1-9][0-9]{2,6}
+	EgressRateLimitKbpsEnabled        bool     `json:"egress_rate_limit_kbps_enabled"`
+	ExcludedNetworkIDs                []string `json:"excluded_networkconf_ids,omitempty"`
+	Forward                           string   `json:"forward,omitempty"` // all|native|customize|disabled
+	FullDuplex                        bool     `json:"full_duplex"`
+	Isolation                         bool     `json:"isolation"`
+	LldpmedEnabled                    bool     `json:"lldpmed_enabled"`
+	LldpmedNotifyEnabled              bool     `json:"lldpmed_notify_enabled"`
+	NATiveNetworkID                   string   `json:"native_networkconf_id"`
+	Name                              string   `json:"name,omitempty"`
+	OpMode                            string   `json:"op_mode,omitempty"`  // switch
+	PoeMode                           string   `json:"poe_mode,omitempty"` // auto|off
+	PortSecurityEnabled               bool     `json:"port_security_enabled"`
+	PortSecurityMACAddress            []string `json:"port_security_mac_address,omitempty"` // ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
+	PriorityQueue1Level               int      `json:"priority_queue1_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	PriorityQueue2Level               int      `json:"priority_queue2_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	PriorityQueue3Level               int      `json:"priority_queue3_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	PriorityQueue4Level               int      `json:"priority_queue4_level,omitempty"`     // [0-9]|[1-9][0-9]|100
+	SettingPreference                 string   `json:"setting_preference,omitempty"`        // auto|manual
+	ShowTrafficRestrictionAsAllowlist bool     `json:"show_traffic_restriction_as_allowlist"`
+	Speed                             int      `json:"speed,omitempty"` // 10|100|1000|2500|5000|10000|20000|25000|40000|50000|100000
+	StormctrlBroadcastastEnabled      bool     `json:"stormctrl_bcast_enabled"`
+	StormctrlBroadcastastLevel        int      `json:"stormctrl_bcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlBroadcastastRate         int      `json:"stormctrl_bcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StormctrlMcastEnabled             bool     `json:"stormctrl_mcast_enabled"`
+	StormctrlMcastLevel               int      `json:"stormctrl_mcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlMcastRate                int      `json:"stormctrl_mcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StormctrlType                     string   `json:"stormctrl_type,omitempty"`        // level|rate
+	StormctrlUcastEnabled             bool     `json:"stormctrl_ucast_enabled"`
+	StormctrlUcastLevel               int      `json:"stormctrl_ucast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlUcastRate                int      `json:"stormctrl_ucast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StpPortMode                       bool     `json:"stp_port_mode"`
+	VoiceNetworkID                    string   `json:"voice_networkconf_id"`
 }
 
 func (dst *PortProfile) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/paultyng/go-unifi/unifi/schedule_task.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/schedule_task.generated.go
@@ -25,16 +25,11 @@ type ScheduleTask struct {
 	NoDelete bool   `json:"attr_no_delete,omitempty"`
 	NoEdit   bool   `json:"attr_no_edit,omitempty"`
 
-	Action                  string                       `json:"action,omitempty"` // stream|upgrade
-	AdditionalSoundsEnabled bool                         `json:"additional_sounds_enabled"`
-	BroadcastgroupID        string                       `json:"broadcastgroup_id"`
-	CronExpr                string                       `json:"cron_expr,omitempty"`
-	ExecuteOnlyOnce         bool                         `json:"execute_only_once"`
-	MediafileID             string                       `json:"mediafile_id"`
-	Name                    string                       `json:"name,omitempty"`
-	SampleFilename          string                       `json:"sample_filename,omitempty"`
-	StreamType              string                       `json:"stream_type,omitempty"` // media|sample
-	UpgradeTargets          []ScheduleTaskUpgradeTargets `json:"upgrade_targets,omitempty"`
+	Action          string                       `json:"action,omitempty"` // upgrade
+	CronExpr        string                       `json:"cron_expr,omitempty"`
+	ExecuteOnlyOnce bool                         `json:"execute_only_once"`
+	Name            string                       `json:"name,omitempty"`
+	UpgradeTargets  []ScheduleTaskUpgradeTargets `json:"upgrade_targets,omitempty"`
 }
 
 func (dst *ScheduleTask) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/paultyng/go-unifi/unifi/setting_guest_access.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/setting_guest_access.generated.go
@@ -29,8 +29,7 @@ type SettingGuestAccess struct {
 
 	AllowedSubnet                          string   `json:"allowed_subnet_,omitempty"`
 	Auth                                   string   `json:"auth,omitempty"` // none|hotspot|facebook_wifi|custom
-	AuthorizeUseSandbox                    bool     `json:"authorize_use_sandbox"`
-	CustomIP                               string   `json:"custom_ip"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
+	CustomIP                               string   `json:"custom_ip"`      // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
 	EcEnabled                              bool     `json:"ec_enabled"`
 	Expire                                 string   `json:"expire,omitempty"`        // [\d]+|custom
 	ExpireNumber                           int      `json:"expire_number,omitempty"` // ^[1-9][0-9]{0,5}|1000000$
@@ -41,31 +40,35 @@ type SettingGuestAccess struct {
 	FacebookWifiBlockHttps                 bool     `json:"facebook_wifi_block_https"`
 	FacebookWifiGwID                       string   `json:"facebook_wifi_gw_id"`
 	FacebookWifiGwName                     string   `json:"facebook_wifi_gw_name,omitempty"`
-	Gateway                                string   `json:"gateway,omitempty"` // paypal|stripe|authorize|quickpay|merchantwarrior|ippay
+	Gateway                                string   `json:"gateway,omitempty"` // stripe
 	GoogleClientID                         string   `json:"google_client_id"`
 	GoogleDomain                           string   `json:"google_domain,omitempty"`
 	GoogleEnabled                          bool     `json:"google_enabled"`
 	GoogleScopeEmail                       bool     `json:"google_scope_email"`
-	IPpayUseSandbox                        bool     `json:"ippay_use_sandbox"`
-	MerchantwarriorUseSandbox              bool     `json:"merchantwarrior_use_sandbox"`
 	PasswordEnabled                        bool     `json:"password_enabled"`
 	PaymentEnabled                         bool     `json:"payment_enabled"`
-	PaypalUseSandbox                       bool     `json:"paypal_use_sandbox"`
 	PortalCustomized                       bool     `json:"portal_customized"`
+	PortalCustomizedAuthenticationText     string   `json:"portal_customized_authentication_text,omitempty"`
 	PortalCustomizedBgColor                string   `json:"portal_customized_bg_color"` // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
 	PortalCustomizedBgImageEnabled         bool     `json:"portal_customized_bg_image_enabled"`
 	PortalCustomizedBgImageFilename        string   `json:"portal_customized_bg_image_filename,omitempty"`
 	PortalCustomizedBgImageTile            bool     `json:"portal_customized_bg_image_tile"`
+	PortalCustomizedBgType                 string   `json:"portal_customized_bg_type,omitempty"`     // color|image|gallery
 	PortalCustomizedBoxColor               string   `json:"portal_customized_box_color"`             // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
 	PortalCustomizedBoxLinkColor           string   `json:"portal_customized_box_link_color"`        // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
 	PortalCustomizedBoxOpacity             int      `json:"portal_customized_box_opacity,omitempty"` // ^[1-9][0-9]?$|^100$|^$
+	PortalCustomizedBoxRADIUS              int      `json:"portal_customized_box_radius,omitempty"`  // [0-9]|[1-4][0-9]|50
 	PortalCustomizedBoxTextColor           string   `json:"portal_customized_box_text_color"`        // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
 	PortalCustomizedButtonColor            string   `json:"portal_customized_button_color"`          // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
-	PortalCustomizedButtonTextColor        string   `json:"portal_customized_button_text_color"`     // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
-	PortalCustomizedLanguages              []string `json:"portal_customized_languages,omitempty"`   // ^[a-z]{2}(_[A-Z]{2})*$
-	PortalCustomizedLinkColor              string   `json:"portal_customized_link_color"`            // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
+	PortalCustomizedButtonText             string   `json:"portal_customized_button_text,omitempty"`
+	PortalCustomizedButtonTextColor        string   `json:"portal_customized_button_text_color"`   // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
+	PortalCustomizedLanguages              []string `json:"portal_customized_languages,omitempty"` // ^[a-z]{2}([_-][a-zA-Z]{2,4})*$
+	PortalCustomizedLinkColor              string   `json:"portal_customized_link_color"`          // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
 	PortalCustomizedLogoEnabled            bool     `json:"portal_customized_logo_enabled"`
 	PortalCustomizedLogoFilename           string   `json:"portal_customized_logo_filename,omitempty"`
+	PortalCustomizedLogoPosition           string   `json:"portal_customized_logo_position,omitempty"` // left|center|right
+	PortalCustomizedLogoSize               int      `json:"portal_customized_logo_size,omitempty"`     // 6[4-9]|[7-9][0-9]|1[0-8][0-9]|19[0-2]
+	PortalCustomizedSuccessText            string   `json:"portal_customized_success_text,omitempty"`
 	PortalCustomizedTextColor              string   `json:"portal_customized_text_color"` // ^#[a-zA-Z0-9]{6}$|^#[a-zA-Z0-9]{3}$|^$
 	PortalCustomizedTitle                  string   `json:"portal_customized_title,omitempty"`
 	PortalCustomizedTos                    string   `json:"portal_customized_tos,omitempty"`
@@ -78,7 +81,6 @@ type SettingGuestAccess struct {
 	PortalEnabled                          bool     `json:"portal_enabled"`
 	PortalHostname                         string   `json:"portal_hostname"` // ^[a-zA-Z0-9.-]+$|^$
 	PortalUseHostname                      bool     `json:"portal_use_hostname"`
-	QuickpayTestmode                       bool     `json:"quickpay_testmode"`
 	RADIUSAuthType                         string   `json:"radius_auth_type,omitempty"` // chap|mschapv2
 	RADIUSDisconnectEnabled                bool     `json:"radius_disconnect_enabled"`
 	RADIUSDisconnectPort                   int      `json:"radius_disconnect_port,omitempty"` // [1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-4][0-9]{2}|[6][5][5][0-2][0-9]|[6][5][5][3][0-5]
@@ -91,29 +93,16 @@ type SettingGuestAccess struct {
 	RestrictedDNSEnabled                   bool     `json:"restricted_dns_enabled"`
 	RestrictedDNSServers                   []string `json:"restricted_dns_servers,omitempty"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
 	RestrictedSubnet                       string   `json:"restricted_subnet_,omitempty"`
-	SettingPreference                      string   `json:"setting_preference,omitempty"` // auto|manual
-	TemplateEngine                         string   `json:"template_engine,omitempty"`    // jsp|angular
+	TemplateEngine                         string   `json:"template_engine,omitempty"` // jsp|angular
 	VoucherCustomized                      bool     `json:"voucher_customized"`
 	VoucherEnabled                         bool     `json:"voucher_enabled"`
 	WechatAppID                            string   `json:"wechat_app_id"`
 	WechatEnabled                          bool     `json:"wechat_enabled"`
 	WechatShopID                           string   `json:"wechat_shop_id"`
-	XAuthorizeLoginid                      string   `json:"x_authorize_loginid,omitempty"`
-	XAuthorizeTransactionkey               string   `json:"x_authorize_transactionkey,omitempty"`
 	XFacebookAppSecret                     string   `json:"x_facebook_app_secret,omitempty"`
 	XFacebookWifiGwSecret                  string   `json:"x_facebook_wifi_gw_secret,omitempty"`
 	XGoogleClientSecret                    string   `json:"x_google_client_secret,omitempty"`
-	XIPpayTerminalid                       string   `json:"x_ippay_terminalid,omitempty"`
-	XMerchantwarriorApikey                 string   `json:"x_merchantwarrior_apikey,omitempty"`
-	XMerchantwarriorApipassphrase          string   `json:"x_merchantwarrior_apipassphrase,omitempty"`
-	XMerchantwarriorMerchantuuid           string   `json:"x_merchantwarrior_merchantuuid,omitempty"`
 	XPassword                              string   `json:"x_password,omitempty"`
-	XPaypalPassword                        string   `json:"x_paypal_password,omitempty"`
-	XPaypalSignature                       string   `json:"x_paypal_signature,omitempty"`
-	XPaypalUsername                        string   `json:"x_paypal_username,omitempty"`
-	XQuickpayAgreementid                   string   `json:"x_quickpay_agreementid,omitempty"`
-	XQuickpayApikey                        string   `json:"x_quickpay_apikey,omitempty"`
-	XQuickpayMerchantid                    string   `json:"x_quickpay_merchantid,omitempty"`
 	XStripeApiKey                          string   `json:"x_stripe_api_key,omitempty"`
 	XWechatAppSecret                       string   `json:"x_wechat_app_secret,omitempty"`
 	XWechatSecretKey                       string   `json:"x_wechat_secret_key,omitempty"`
@@ -125,6 +114,8 @@ func (dst *SettingGuestAccess) UnmarshalJSON(b []byte) error {
 		ExpireNumber               emptyStringInt `json:"expire_number"`
 		ExpireUnit                 emptyStringInt `json:"expire_unit"`
 		PortalCustomizedBoxOpacity emptyStringInt `json:"portal_customized_box_opacity"`
+		PortalCustomizedBoxRADIUS  emptyStringInt `json:"portal_customized_box_radius"`
+		PortalCustomizedLogoSize   emptyStringInt `json:"portal_customized_logo_size"`
 		RADIUSDisconnectPort       emptyStringInt `json:"radius_disconnect_port"`
 
 		*Alias
@@ -139,6 +130,8 @@ func (dst *SettingGuestAccess) UnmarshalJSON(b []byte) error {
 	dst.ExpireNumber = int(aux.ExpireNumber)
 	dst.ExpireUnit = int(aux.ExpireUnit)
 	dst.PortalCustomizedBoxOpacity = int(aux.PortalCustomizedBoxOpacity)
+	dst.PortalCustomizedBoxRADIUS = int(aux.PortalCustomizedBoxRADIUS)
+	dst.PortalCustomizedLogoSize = int(aux.PortalCustomizedLogoSize)
 	dst.RADIUSDisconnectPort = int(aux.RADIUSDisconnectPort)
 
 	return nil

--- a/vendor/github.com/paultyng/go-unifi/unifi/setting_magic_site_to_site_vpn.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/setting_magic_site_to_site_vpn.generated.go
@@ -1,0 +1,87 @@
+// Code generated from ace.jar fields *.json files
+// DO NOT EDIT.
+
+package unifi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// just to fix compile issues with the import
+var (
+	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
+)
+
+type SettingMagicSiteToSiteVpn struct {
+	ID     string `json:"_id,omitempty"`
+	SiteID string `json:"site_id,omitempty"`
+
+	Hidden   bool   `json:"attr_hidden,omitempty"`
+	HiddenID string `json:"attr_hidden_id,omitempty"`
+	NoDelete bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   bool   `json:"attr_no_edit,omitempty"`
+
+	Key string `json:"key"`
+
+	Enabled bool `json:"enabled"`
+}
+
+func (dst *SettingMagicSiteToSiteVpn) UnmarshalJSON(b []byte) error {
+	type Alias SettingMagicSiteToSiteVpn
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) getSettingMagicSiteToSiteVpn(ctx context.Context, site string) (*SettingMagicSiteToSiteVpn, error) {
+	var respBody struct {
+		Meta meta                        `json:"meta"`
+		Data []SettingMagicSiteToSiteVpn `json:"data"`
+	}
+
+	err := c.do(ctx, "GET", fmt.Sprintf("s/%s/get/setting/magic_site_to_site_vpn", site), nil, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(respBody.Data) != 1 {
+		return nil, &NotFoundError{}
+	}
+
+	d := respBody.Data[0]
+	return &d, nil
+}
+
+func (c *Client) updateSettingMagicSiteToSiteVpn(ctx context.Context, site string, d *SettingMagicSiteToSiteVpn) (*SettingMagicSiteToSiteVpn, error) {
+	var respBody struct {
+		Meta meta                        `json:"meta"`
+		Data []SettingMagicSiteToSiteVpn `json:"data"`
+	}
+
+	d.Key = "magic_site_to_site_vpn"
+	err := c.do(ctx, "PUT", fmt.Sprintf("s/%s/set/setting/magic_site_to_site_vpn", site), d, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(respBody.Data) != 1 {
+		return nil, &NotFoundError{}
+	}
+
+	new := respBody.Data[0]
+
+	return &new, nil
+}

--- a/vendor/github.com/paultyng/go-unifi/unifi/user.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/user.generated.go
@@ -28,20 +28,22 @@ type User struct {
 	DevIdOverride int    `json:"dev_id_override,omitempty"` // non-generated field
 	IP            string `json:"ip,omitempty"`              // non-generated field
 
-	Blocked               bool   `json:"blocked,omitempty"`
-	FixedApEnabled        bool   `json:"fixed_ap_enabled"`
-	FixedApMAC            string `json:"fixed_ap_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
-	FixedIP               string `json:"fixed_ip,omitempty"`
-	Hostname              string `json:"hostname,omitempty"`
-	LastSeen              int    `json:"last_seen,omitempty"`
-	LocalDNSRecord        string `json:"local_dns_record,omitempty"`
-	LocalDNSRecordEnabled bool   `json:"local_dns_record_enabled"`
-	MAC                   string `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
-	Name                  string `json:"name,omitempty"`
-	NetworkID             string `json:"network_id"`
-	Note                  string `json:"note,omitempty"`
-	UseFixedIP            bool   `json:"use_fixedip"`
-	UserGroupID           string `json:"usergroup_id"`
+	Blocked                       bool   `json:"blocked,omitempty"`
+	FixedApEnabled                bool   `json:"fixed_ap_enabled"`
+	FixedApMAC                    string `json:"fixed_ap_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	FixedIP                       string `json:"fixed_ip,omitempty"`
+	Hostname                      string `json:"hostname,omitempty"`
+	LastSeen                      int    `json:"last_seen,omitempty"`
+	LocalDNSRecord                string `json:"local_dns_record,omitempty"`
+	LocalDNSRecordEnabled         bool   `json:"local_dns_record_enabled"`
+	MAC                           string `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	Name                          string `json:"name,omitempty"`
+	NetworkID                     string `json:"network_id"`
+	Note                          string `json:"note,omitempty"`
+	UseFixedIP                    bool   `json:"use_fixedip"`
+	UserGroupID                   string `json:"usergroup_id"`
+	VirtualNetworkOverrideEnabled bool   `json:"virtual_network_override_enabled"`
+	VirtualNetworkOverrideID      string `json:"virtual_network_override_id"`
 }
 
 func (dst *User) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/paultyng/go-unifi/unifi/user.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/user.go
@@ -131,6 +131,19 @@ func (c *Client) DeleteUserByMAC(ctx context.Context, site, mac string) error {
 	return nil
 }
 
+func (c *Client) KickUserByMAC(ctx context.Context, site, mac string) error {
+	users, err := c.stamgr(ctx, site, "kick-sta", map[string]interface{}{
+		"mac": mac,
+	})
+	if err != nil {
+		return err
+	}
+	if len(users) != 1 {
+		return &NotFoundError{}
+	}
+	return nil
+}
+
 func (c *Client) OverrideUserFingerprint(ctx context.Context, site, mac string, devIdOveride int) error {
 	reqBody := map[string]interface{}{
 		"mac":             mac,

--- a/vendor/github.com/paultyng/go-unifi/unifi/version.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/version.generated.go
@@ -2,4 +2,4 @@
 
 package unifi
 
-const UnifiVersion = "7.3.83"
+const UnifiVersion = "7.4.156"

--- a/vendor/github.com/paultyng/go-unifi/unifi/wlan.generated.go
+++ b/vendor/github.com/paultyng/go-unifi/unifi/wlan.generated.go
@@ -73,7 +73,6 @@ type WLAN struct {
 	Priority                    string                     `json:"priority,omitempty"`   // medium|high|low
 	ProxyArp                    bool                       `json:"proxy_arp"`
 	RADIUSDasEnabled            bool                       `json:"radius_das_enabled"`
-	RADIUSFilterIDEnabled       bool                       `json:"radius_filter_id_enabled"`
 	RADIUSMACAuthEnabled        bool                       `json:"radius_mac_auth_enabled"`
 	RADIUSMACaclEmptyPassword   bool                       `json:"radius_macacl_empty_password"`
 	RADIUSMACaclFormat          string                     `json:"radius_macacl_format,omitempty"` // none_lower|hyphen_lower|colon_lower|none_upper|hyphen_upper|colon_upper

--- a/vendor/go.uber.org/multierr/CHANGELOG.md
+++ b/vendor/go.uber.org/multierr/CHANGELOG.md
@@ -1,6 +1,14 @@
 Releases
 ========
 
+v1.9.0 (2022-12-12)
+===================
+
+-   Add `AppendFunc` that allow passsing functions to similar to
+    `AppendInvoke`.
+
+-   Bump up yaml.v3 dependency to 3.0.1.
+
 v1.8.0 (2022-02-28)
 ===================
 

--- a/vendor/go.uber.org/multierr/error.go
+++ b/vendor/go.uber.org/multierr/error.go
@@ -20,106 +20,109 @@
 
 // Package multierr allows combining one or more errors together.
 //
-// Overview
+// # Overview
 //
 // Errors can be combined with the use of the Combine function.
 //
-// 	multierr.Combine(
-// 		reader.Close(),
-// 		writer.Close(),
-// 		conn.Close(),
-// 	)
+//	multierr.Combine(
+//		reader.Close(),
+//		writer.Close(),
+//		conn.Close(),
+//	)
 //
 // If only two errors are being combined, the Append function may be used
 // instead.
 //
-// 	err = multierr.Append(reader.Close(), writer.Close())
+//	err = multierr.Append(reader.Close(), writer.Close())
 //
 // The underlying list of errors for a returned error object may be retrieved
 // with the Errors function.
 //
-// 	errors := multierr.Errors(err)
-// 	if len(errors) > 0 {
-// 		fmt.Println("The following errors occurred:", errors)
-// 	}
+//	errors := multierr.Errors(err)
+//	if len(errors) > 0 {
+//		fmt.Println("The following errors occurred:", errors)
+//	}
 //
-// Appending from a loop
+// # Appending from a loop
 //
 // You sometimes need to append into an error from a loop.
 //
-// 	var err error
-// 	for _, item := range items {
-// 		err = multierr.Append(err, process(item))
-// 	}
+//	var err error
+//	for _, item := range items {
+//		err = multierr.Append(err, process(item))
+//	}
 //
 // Cases like this may require knowledge of whether an individual instance
 // failed. This usually requires introduction of a new variable.
 //
-// 	var err error
-// 	for _, item := range items {
-// 		if perr := process(item); perr != nil {
-// 			log.Warn("skipping item", item)
-// 			err = multierr.Append(err, perr)
-// 		}
-// 	}
+//	var err error
+//	for _, item := range items {
+//		if perr := process(item); perr != nil {
+//			log.Warn("skipping item", item)
+//			err = multierr.Append(err, perr)
+//		}
+//	}
 //
 // multierr includes AppendInto to simplify cases like this.
 //
-// 	var err error
-// 	for _, item := range items {
-// 		if multierr.AppendInto(&err, process(item)) {
-// 			log.Warn("skipping item", item)
-// 		}
-// 	}
+//	var err error
+//	for _, item := range items {
+//		if multierr.AppendInto(&err, process(item)) {
+//			log.Warn("skipping item", item)
+//		}
+//	}
 //
 // This will append the error into the err variable, and return true if that
 // individual error was non-nil.
 //
-// See AppendInto for more information.
+// See [AppendInto] for more information.
 //
-// Deferred Functions
+// # Deferred Functions
 //
 // Go makes it possible to modify the return value of a function in a defer
 // block if the function was using named returns. This makes it possible to
 // record resource cleanup failures from deferred blocks.
 //
-// 	func sendRequest(req Request) (err error) {
-// 		conn, err := openConnection()
-// 		if err != nil {
-// 			return err
-// 		}
-// 		defer func() {
-// 			err = multierr.Append(err, conn.Close())
-// 		}()
-// 		// ...
-// 	}
+//	func sendRequest(req Request) (err error) {
+//		conn, err := openConnection()
+//		if err != nil {
+//			return err
+//		}
+//		defer func() {
+//			err = multierr.Append(err, conn.Close())
+//		}()
+//		// ...
+//	}
 //
 // multierr provides the Invoker type and AppendInvoke function to make cases
 // like the above simpler and obviate the need for a closure. The following is
 // roughly equivalent to the example above.
 //
-// 	func sendRequest(req Request) (err error) {
-// 		conn, err := openConnection()
-// 		if err != nil {
-// 			return err
-// 		}
-// 		defer multierr.AppendInvoke(&err, multierr.Close(conn))
-// 		// ...
-// 	}
+//	func sendRequest(req Request) (err error) {
+//		conn, err := openConnection()
+//		if err != nil {
+//			return err
+//		}
+//		defer multierr.AppendInvoke(&err, multierr.Close(conn))
+//		// ...
+//	}
 //
-// See AppendInvoke and Invoker for more information.
+// See [AppendInvoke] and [Invoker] for more information.
 //
-// Advanced Usage
+// NOTE: If you're modifying an error from inside a defer, you MUST use a named
+// return value for that function.
+//
+// # Advanced Usage
 //
 // Errors returned by Combine and Append MAY implement the following
 // interface.
 //
-// 	type errorGroup interface {
-// 		// Returns a slice containing the underlying list of errors.
-// 		//
-// 		// This slice MUST NOT be modified by the caller.
-// 		Errors() []error
-// 	}
+//	type errorGroup interface {
+//		// Returns a slice containing the underlying list of errors.
+//		//
+//		// This slice MUST NOT be modified by the caller.
+//		Errors() []error
+//	}
 //
 // Note that if you need access to list of errors behind a multierr error, you
 // should prefer using the Errors function. That said, if you need cheap
@@ -128,13 +131,13 @@
 // because errors returned by Combine and Append are not guaranteed to
 // implement this interface.
 //
-// 	var errors []error
-// 	group, ok := err.(errorGroup)
-// 	if ok {
-// 		errors = group.Errors()
-// 	} else {
-// 		errors = []error{err}
-// 	}
+//	var errors []error
+//	group, ok := err.(errorGroup)
+//	if ok {
+//		errors = group.Errors()
+//	} else {
+//		errors = []error{err}
+//	}
 package multierr // import "go.uber.org/multierr"
 
 import (
@@ -185,8 +188,8 @@ type errorGroup interface {
 // Errors returns a slice containing zero or more errors that the supplied
 // error is composed of. If the error is nil, a nil slice is returned.
 //
-// 	err := multierr.Append(r.Close(), w.Close())
-// 	errors := multierr.Errors(err)
+//	err := multierr.Append(r.Close(), w.Close())
+//	errors := multierr.Errors(err)
 //
 // If the error is not composed of other errors, the returned slice contains
 // just the error that was passed in.
@@ -209,10 +212,7 @@ func Errors(err error) []error {
 		return []error{err}
 	}
 
-	errors := eg.Errors()
-	result := make([]error, len(errors))
-	copy(result, errors)
-	return result
+	return append(([]error)(nil), eg.Errors()...)
 }
 
 // multiError is an error that holds one or more errors.
@@ -393,8 +393,7 @@ func fromSlice(errors []error) error {
 			// Otherwise "errors" escapes to the heap
 			// unconditionally for all other cases.
 			// This lets us optimize for the "no errors" case.
-			out := make([]error, len(errors))
-			copy(out, errors)
+			out := append(([]error)(nil), errors...)
 			return &multiError{errors: out}
 		}
 	}
@@ -420,32 +419,32 @@ func fromSlice(errors []error) error {
 // If zero arguments were passed or if all items are nil, a nil error is
 // returned.
 //
-// 	Combine(nil, nil)  // == nil
+//	Combine(nil, nil)  // == nil
 //
 // If only a single error was passed, it is returned as-is.
 //
-// 	Combine(err)  // == err
+//	Combine(err)  // == err
 //
 // Combine skips over nil arguments so this function may be used to combine
 // together errors from operations that fail independently of each other.
 //
-// 	multierr.Combine(
-// 		reader.Close(),
-// 		writer.Close(),
-// 		pipe.Close(),
-// 	)
+//	multierr.Combine(
+//		reader.Close(),
+//		writer.Close(),
+//		pipe.Close(),
+//	)
 //
 // If any of the passed errors is a multierr error, it will be flattened along
 // with the other errors.
 //
-// 	multierr.Combine(multierr.Combine(err1, err2), err3)
-// 	// is the same as
-// 	multierr.Combine(err1, err2, err3)
+//	multierr.Combine(multierr.Combine(err1, err2), err3)
+//	// is the same as
+//	multierr.Combine(err1, err2, err3)
 //
 // The returned error formats into a readable multi-line error message if
 // formatted with %+v.
 //
-// 	fmt.Sprintf("%+v", multierr.Combine(err1, err2))
+//	fmt.Sprintf("%+v", multierr.Combine(err1, err2))
 func Combine(errors ...error) error {
 	return fromSlice(errors)
 }
@@ -455,16 +454,19 @@ func Combine(errors ...error) error {
 // This function is a specialization of Combine for the common case where
 // there are only two errors.
 //
-// 	err = multierr.Append(reader.Close(), writer.Close())
+//	err = multierr.Append(reader.Close(), writer.Close())
 //
 // The following pattern may also be used to record failure of deferred
 // operations without losing information about the original error.
 //
-// 	func doSomething(..) (err error) {
-// 		f := acquireResource()
-// 		defer func() {
-// 			err = multierr.Append(err, f.Close())
-// 		}()
+//	func doSomething(..) (err error) {
+//		f := acquireResource()
+//		defer func() {
+//			err = multierr.Append(err, f.Close())
+//		}()
+//
+// Note that the variable MUST be a named return to append an error to it from
+// the defer statement. See also [AppendInvoke].
 func Append(left error, right error) error {
 	switch {
 	case left == nil:
@@ -494,37 +496,37 @@ func Append(left error, right error) error {
 // AppendInto appends an error into the destination of an error pointer and
 // returns whether the error being appended was non-nil.
 //
-// 	var err error
-// 	multierr.AppendInto(&err, r.Close())
-// 	multierr.AppendInto(&err, w.Close())
+//	var err error
+//	multierr.AppendInto(&err, r.Close())
+//	multierr.AppendInto(&err, w.Close())
 //
 // The above is equivalent to,
 //
-// 	err := multierr.Append(r.Close(), w.Close())
+//	err := multierr.Append(r.Close(), w.Close())
 //
 // As AppendInto reports whether the provided error was non-nil, it may be
 // used to build a multierr error in a loop more ergonomically. For example:
 //
-// 	var err error
-// 	for line := range lines {
-// 		var item Item
-// 		if multierr.AppendInto(&err, parse(line, &item)) {
-// 			continue
-// 		}
-// 		items = append(items, item)
-// 	}
+//	var err error
+//	for line := range lines {
+//		var item Item
+//		if multierr.AppendInto(&err, parse(line, &item)) {
+//			continue
+//		}
+//		items = append(items, item)
+//	}
 //
 // Compare this with a version that relies solely on Append:
 //
-// 	var err error
-// 	for line := range lines {
-// 		var item Item
-// 		if parseErr := parse(line, &item); parseErr != nil {
-// 			err = multierr.Append(err, parseErr)
-// 			continue
-// 		}
-// 		items = append(items, item)
-// 	}
+//	var err error
+//	for line := range lines {
+//		var item Item
+//		if parseErr := parse(line, &item); parseErr != nil {
+//			err = multierr.Append(err, parseErr)
+//			continue
+//		}
+//		items = append(items, item)
+//	}
 func AppendInto(into *error, err error) (errored bool) {
 	if into == nil {
 		// We panic if 'into' is nil. This is not documented above
@@ -545,7 +547,7 @@ func AppendInto(into *error, err error) (errored bool) {
 // AppendInvoke to append the result of calling the function into an error.
 // This allows you to conveniently defer capture of failing operations.
 //
-// See also, Close and Invoke.
+// See also, [Close] and [Invoke].
 type Invoker interface {
 	Invoke() error
 }
@@ -556,19 +558,22 @@ type Invoker interface {
 //
 // For example,
 //
-// 	func processReader(r io.Reader) (err error) {
-// 		scanner := bufio.NewScanner(r)
-// 		defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
-// 		for scanner.Scan() {
-// 			// ...
-// 		}
-// 		// ...
-// 	}
+//	func processReader(r io.Reader) (err error) {
+//		scanner := bufio.NewScanner(r)
+//		defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
+//		for scanner.Scan() {
+//			// ...
+//		}
+//		// ...
+//	}
 //
 // In this example, the following line will construct the Invoker right away,
 // but defer the invocation of scanner.Err() until the function returns.
 //
-// 	defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
+//	defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
+//
+// Note that the error you're appending to from the defer statement MUST be a
+// named return.
 type Invoke func() error
 
 // Invoke calls the supplied function and returns its result.
@@ -579,19 +584,22 @@ func (i Invoke) Invoke() error { return i() }
 //
 // For example,
 //
-// 	func processFile(path string) (err error) {
-// 		f, err := os.Open(path)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		defer multierr.AppendInvoke(&err, multierr.Close(f))
-// 		return processReader(f)
-// 	}
+//	func processFile(path string) (err error) {
+//		f, err := os.Open(path)
+//		if err != nil {
+//			return err
+//		}
+//		defer multierr.AppendInvoke(&err, multierr.Close(f))
+//		return processReader(f)
+//	}
 //
 // In this example, multierr.Close will construct the Invoker right away, but
 // defer the invocation of f.Close until the function returns.
 //
-// 	defer multierr.AppendInvoke(&err, multierr.Close(f))
+//	defer multierr.AppendInvoke(&err, multierr.Close(f))
+//
+// Note that the error you're appending to from the defer statement MUST be a
+// named return.
 func Close(closer io.Closer) Invoker {
 	return Invoke(closer.Close)
 }
@@ -601,52 +609,73 @@ func Close(closer io.Closer) Invoker {
 // invocation of fallible operations until a function returns, and capture the
 // resulting errors.
 //
-// 	func doSomething(...) (err error) {
-// 		// ...
-// 		f, err := openFile(..)
-// 		if err != nil {
-// 			return err
-// 		}
+//	func doSomething(...) (err error) {
+//		// ...
+//		f, err := openFile(..)
+//		if err != nil {
+//			return err
+//		}
 //
-// 		// multierr will call f.Close() when this function returns and
-// 		// if the operation fails, its append its error into the
-// 		// returned error.
-// 		defer multierr.AppendInvoke(&err, multierr.Close(f))
+//		// multierr will call f.Close() when this function returns and
+//		// if the operation fails, its append its error into the
+//		// returned error.
+//		defer multierr.AppendInvoke(&err, multierr.Close(f))
 //
-// 		scanner := bufio.NewScanner(f)
-// 		// Similarly, this scheduled scanner.Err to be called and
-// 		// inspected when the function returns and append its error
-// 		// into the returned error.
-// 		defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
+//		scanner := bufio.NewScanner(f)
+//		// Similarly, this scheduled scanner.Err to be called and
+//		// inspected when the function returns and append its error
+//		// into the returned error.
+//		defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
 //
-// 		// ...
-// 	}
+//		// ...
+//	}
+//
+// NOTE: If used with a defer, the error variable MUST be a named return.
 //
 // Without defer, AppendInvoke behaves exactly like AppendInto.
 //
-// 	err := // ...
-// 	multierr.AppendInvoke(&err, mutltierr.Invoke(foo))
+//	err := // ...
+//	multierr.AppendInvoke(&err, mutltierr.Invoke(foo))
 //
-// 	// ...is roughly equivalent to...
+//	// ...is roughly equivalent to...
 //
-// 	err := // ...
-// 	multierr.AppendInto(&err, foo())
+//	err := // ...
+//	multierr.AppendInto(&err, foo())
 //
 // The advantage of the indirection introduced by Invoker is to make it easy
 // to defer the invocation of a function. Without this indirection, the
 // invoked function will be evaluated at the time of the defer block rather
 // than when the function returns.
 //
-// 	// BAD: This is likely not what the caller intended. This will evaluate
-// 	// foo() right away and append its result into the error when the
-// 	// function returns.
-// 	defer multierr.AppendInto(&err, foo())
+//	// BAD: This is likely not what the caller intended. This will evaluate
+//	// foo() right away and append its result into the error when the
+//	// function returns.
+//	defer multierr.AppendInto(&err, foo())
 //
-// 	// GOOD: This will defer invocation of foo unutil the function returns.
-// 	defer multierr.AppendInvoke(&err, multierr.Invoke(foo))
+//	// GOOD: This will defer invocation of foo unutil the function returns.
+//	defer multierr.AppendInvoke(&err, multierr.Invoke(foo))
 //
 // multierr provides a few Invoker implementations out of the box for
-// convenience. See Invoker for more information.
+// convenience. See [Invoker] for more information.
 func AppendInvoke(into *error, invoker Invoker) {
 	AppendInto(into, invoker.Invoke())
+}
+
+// AppendFunc is a shorthand for [AppendInvoke].
+// It allows using function or method value directly
+// without having to wrap it into an [Invoker] interface.
+//
+//	func doSomething(...) (err error) {
+//		w, err := startWorker(...)
+//		if err != nil {
+//			return err
+//		}
+//
+//		// multierr will call w.Stop() when this function returns and
+//		// if the operation fails, it appends its error into the
+//		// returned error.
+//		defer multierr.AppendFunc(&err, w.Stop)
+//	}
+func AppendFunc(into *error, fn func() error) {
+	AppendInvoke(into, Invoke(fn))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -87,6 +87,9 @@ github.com/ProtonMail/go-crypto/openpgp/s2k
 # github.com/agext/levenshtein v1.2.3
 ## explicit
 github.com/agext/levenshtein
+# github.com/akerl/terraform-provider-unifi v0.41.8
+## explicit; go 1.20
+github.com/akerl/terraform-provider-unifi/internal/provider
 # github.com/alexkohler/nakedret/v2 v2.0.2
 ## explicit; go 1.18
 github.com/alexkohler/nakedret/v2
@@ -854,7 +857,7 @@ github.com/hashicorp/terraform-plugin-sdk/v2/internal/tfdiags
 github.com/hashicorp/terraform-plugin-sdk/v2/meta
 github.com/hashicorp/terraform-plugin-sdk/v2/plugin
 github.com/hashicorp/terraform-plugin-sdk/v2/terraform
-# github.com/hashicorp/terraform-plugin-testing v1.3.0
+# github.com/hashicorp/terraform-plugin-testing v1.4.0
 ## explicit; go 1.19
 github.com/hashicorp/terraform-plugin-testing/helper/acctest
 github.com/hashicorp/terraform-plugin-testing/helper/resource
@@ -867,6 +870,7 @@ github.com/hashicorp/terraform-plugin-testing/internal/plugintest
 github.com/hashicorp/terraform-plugin-testing/internal/tfdiags
 github.com/hashicorp/terraform-plugin-testing/plancheck
 github.com/hashicorp/terraform-plugin-testing/terraform
+github.com/hashicorp/terraform-plugin-testing/tfjsonpath
 github.com/hashicorp/terraform-plugin-testing/tfversion
 # github.com/hashicorp/terraform-registry-address v0.2.2
 ## explicit; go 1.19
@@ -1183,7 +1187,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.1.9
 ## explicit; go 1.17
 github.com/opencontainers/runc/libcontainer/user
-# github.com/paultyng/go-unifi v1.32.0
+# github.com/paultyng/go-unifi v1.33.0
 ## explicit; go 1.18
 github.com/paultyng/go-unifi/unifi
 # github.com/pelletier/go-toml v1.9.5
@@ -1569,8 +1573,8 @@ go.tmz.dev/musttag
 # go.uber.org/atomic v1.10.0
 ## explicit; go 1.18
 go.uber.org/atomic
-# go.uber.org/multierr v1.8.0
-## explicit; go 1.14
+# go.uber.org/multierr v1.9.0
+## explicit; go 1.19
 go.uber.org/multierr
 # go.uber.org/zap v1.24.0
 ## explicit; go 1.19


### PR DESCRIPTION
This bundles a couple of updates:

1. Allows "skip" to keep WLAN passphrases out of state files (which would partially resolve #389 )
2. Updates the go-unifi module to 1.33
3. Adjusts port profiles and network resources to account for API changes in v7 and v8 of the Unifi network application

I've also published a version of this provider from my fork that incorporates the above: https://registry.terraform.io/providers/akerl/unifi/latest

I did this largely for my own benefit, since I use this module and didn't want to have to manually install it, but if it's useful for other folks, all the better.