### PR TITLE
Fix missing IP on unifi_user bug

### DIFF
--- a/internal/provider/data_user.go
+++ b/internal/provider/data_user.go
@@ -116,10 +116,7 @@ func dataUserRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 	if resp.UseFixedIP {
 		fixedIP = resp.FixedIP
 	}
-	localDnsRecord := ""
-	if resp.LocalDNSRecordEnabled {
-		localDnsRecord = resp.LocalDNSRecord
-	}
+
 	d.SetId(resp.ID)
 	d.Set("site", site)
 	d.Set("mac", resp.MAC)
@@ -132,7 +129,12 @@ func dataUserRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 	d.Set("dev_id_override", resp.DevIdOverride)
 	d.Set("hostname", resp.Hostname)
 	d.Set("ip", resp.IP)
-	d.Set("ip", localDnsRecord)
+
+	localDnsRecord := ""
+	if resp.LocalDNSRecordEnabled {
+		localDnsRecord = resp.LocalDNSRecord
+		d.Set("ip", localDnsRecord)
+	}
 
 	return nil
 }

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -181,7 +181,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceUserGetResourceData(d *schema.ResourceData) (*unifi.User, error) {
-    fixedIP := d.Get("fixed_ip").(string)
+	fixedIP := d.Get("fixed_ip").(string)
 	localDnsRecord := d.Get("local_dns_record").(string)
 
 	return &unifi.User{

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -181,7 +181,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceUserGetResourceData(d *schema.ResourceData) (*unifi.User, error) {
-	fixedIP := d.Get("fixed_ip").(string)
+    fixedIP := d.Get("fixed_ip").(string)
 	localDnsRecord := d.Get("local_dns_record").(string)
 
 	return &unifi.User{


### PR DESCRIPTION
Hi! Thanks for making this TF provider 😄.

I was trying to use this provider to get an IP address based on a known MAC address, but was getting null results back from the TF `data` resource. I manually checked the REST endpoint to make sure the data was available, which it was. 

After some investigation, I believe an unintentional bug was introduced in [this PR](https://github.com/paultyng/terraform-provider-unifi/pull/293/files) which overwrites the IP even if there is no local DNS record found. I have added a conditional that only overwrites the IP if there is a local DNS record instead.

I have tested this locally and it works in my scenario now 😄