### PR TITLE
Multiple network resource and data source improvements

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -59,7 +59,7 @@ data "unifi_network" "my_network" {
 - `ipv6_pd_prefixid` (String) Specifies the IPv6 Prefix ID.
 - `ipv6_pd_start` (String) Start address of the DHCPv6 range. Used if `ipv6_interface_type` is set to `pd`.
 - `ipv6_pd_stop` (String) End address of the DHCPv6 range. Used if `ipv6_interface_type` is set to `pd`.
-- `ipv6_ra_enable` (Boolean) Specifies whether to enable router advertisements or not.
+- `ipv6_ra_enabled` (Boolean) Specifies whether to enable router advertisements or not.
 - `ipv6_ra_preferred_lifetime` (Number) Lifetime in which the address can be used. Address becomes deprecated afterwards. Must be lower than or equal to `ipv6_ra_valid_lifetime`
 - `ipv6_ra_priority` (String) IPv6 router advertisement priority. Must be one of either `high`, `medium`, or `low`
 - `ipv6_ra_valid_lifetime` (Number) Total lifetime in which the address can be used. Must be equal to or greater than `ipv6_ra_preferred_lifetime`.

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -75,7 +75,7 @@ resource "unifi_network" "wan" {
 - `ipv6_pd_prefixid` (String) Specifies the IPv6 Prefix ID.
 - `ipv6_pd_start` (String) Start address of the DHCPv6 range. Used if `ipv6_interface_type` is set to `pd`.
 - `ipv6_pd_stop` (String) End address of the DHCPv6 range. Used if `ipv6_interface_type` is set to `pd`.
-- `ipv6_ra_enable` (Boolean) Specifies whether to enable router advertisements or not.
+- `ipv6_ra_enabled` (Boolean) Specifies whether to enable router advertisements or not.
 - `ipv6_ra_preferred_lifetime` (Number) Lifetime in which the address can be used. Address becomes deprecated afterwards. Must be lower than or equal to `ipv6_ra_valid_lifetime` Defaults to `14400`.
 - `ipv6_ra_priority` (String) IPv6 router advertisement priority. Must be one of either `high`, `medium`, or `low`
 - `ipv6_ra_valid_lifetime` (Number) Total lifetime in which the address can be used. Must be equal to or greater than `ipv6_ra_preferred_lifetime`. Defaults to `86400`.

--- a/internal/provider/cidr.go
+++ b/internal/provider/cidr.go
@@ -43,14 +43,3 @@ func cidrZeroBased(cidr string) string {
 
 	return cidrNet.String()
 }
-
-func cidrOneBased(cidr string) string {
-	_, cidrNet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return ""
-	}
-
-	cidrNet.IP[3]++
-
-	return cidrNet.String()
-}

--- a/internal/provider/data_network.go
+++ b/internal/provider/data_network.go
@@ -76,7 +76,19 @@ func dataNetwork() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 			},
-
+			"dhcpguard_enabled": {
+				Description: "Whether DHCP guarding is enabled or not on this network.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+			"dhcp_server_ips": {
+				Description: "IPv4 addresses of the DHCP servers on this network",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"dhcp_dns": {
 				Description: "IPv4 addresses for the DNS server to be returned from the DHCP " +
 					"server.",
@@ -86,7 +98,6 @@ func dataNetwork() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
 			"dhcpd_boot_enabled": {
 				Description: "Toggles on the DHCP boot options. will be set to true if you have dhcpd_boot_filename, and dhcpd_boot_server set.",
 				Type:        schema.TypeBool,
@@ -176,7 +187,7 @@ func dataNetwork() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"ipv6_ra_enable": {
+			"ipv6_ra_enabled": {
 				Description: "Specifies whether to enable router advertisements or not.",
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -321,14 +332,27 @@ func dataNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface
 				}
 				wanDNS = append(wanDNS, dns)
 			}
+			dhcpdIPs := []string{}
+			for _, dhcpIP := range []string{
+				n.DHCPDIP1,
+				n.DHCPDIP2,
+				n.DHCPDIP3,
+			} {
+				if dhcpIP == "" {
+					continue
+				}
+				dhcpdIPs = append(dhcpdIPs, dhcpIP)
+			}
 
 			d.SetId(n.ID)
 			d.Set("site", site)
 			d.Set("name", n.Name)
 			d.Set("purpose", n.Purpose)
 			d.Set("vlan_id", n.VLAN)
-			d.Set("subnet", cidrZeroBased(n.IPSubnet))
+			d.Set("subnet", n.IPSubnet)
 			d.Set("network_group", n.NetworkGroup)
+			d.Set("dhcpguard_enabled", n.DHCPguardEnabled)
+			d.Set("dhcp_server_ips", dhcpdIPs)
 			d.Set("dhcp_dns", dhcpDNS)
 			d.Set("dhcp_start", n.DHCPDStart)
 			d.Set("dhcp_stop", n.DHCPDStop)
@@ -343,7 +367,7 @@ func dataNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface
 			d.Set("ipv6_static_subnet", n.IPV6Subnet)
 			d.Set("ipv6_pd_interface", n.IPV6PDInterface)
 			d.Set("ipv6_pd_prefixid", n.IPV6PDPrefixid)
-			d.Set("ipv6_ra_enable", n.IPV6RaEnabled)
+			d.Set("ipv6_ra_enabled", n.IPV6RaEnabled)
 			d.Set("multicast_dns", n.MdnsEnabled)
 			d.Set("wan_ip", n.WANIP)
 			d.Set("wan_netmask", n.WANNetmask)

--- a/internal/provider/resource_network_test.go
+++ b/internal/provider/resource_network_test.go
@@ -514,7 +514,7 @@ resource "unifi_network" "test" {
 
 	ipv6_interface_type = "%[4]s"
 	ipv6_static_subnet  = "%[5]s"
-	ipv6_ra_enable      = true
+	ipv6_ra_enabled     = true
 }
 `, name, subnet, vlan, ipv6Type, ipv6Subnet)
 }


### PR DESCRIPTION
This PR fixes a few things with the Network resource and data source:

* Fix the `ipv6_ra_enabled` option name (it was previously `ipv6_ra_enable` which does not match the JSON field name returned by the API.
* Allow control of the DHCP Guarding option.
* Allow the DHCP server IP addresses to be specified (this can be used in conjunction with DHCP guarding)
* Remove the call to `cidrZeroBased` on the IP Subnet. The subnet field is also used to specify the IP address which is allocated to the USG itself, and this was always being normalized to zero.
* Control which settings are updated based on the IPV6 interface setting. If it is set to `none` then the IPV6 settings are ignored. This removes the need to specify unused IPV6 settings to prevent unstable plans.