### PR TITLE
pre-install TF for acceptance tests

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -48,6 +48,12 @@ jobs:
           go-version-file: "go.mod"
           check-latest: true
 
+      # Pre-install Teraform, so that test cases don't try installing their temporary copy
+      # See https://github.com/hashicorp/terraform-plugin-testing/issues/429
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
       # The acceptance tests sometimes timeout for some unknown reason.
       - name: TF acceptance tests
         uses: "nick-fields/retry@v3"


### PR DESCRIPTION
According to the thread at https://github.com/hashicorp/terraform-plugin-testing/issues/429 the "text file busy" failure which is currently plaguing the tests is a result of each test case trying to install its temporary copy of Terraform. Pre-installing TF should fix it.