### PR TITLE
remove deprecated and inactive linter 'structcheck'

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,6 @@ linters:
     - "nakedret"
     - "nilerr"
     - "staticcheck"
-    - "structcheck"
     - "unconvert"
     - "unused"
 


### PR DESCRIPTION
See https://golangci-lint.run/product/changelog/#v1570